### PR TITLE
Allow to get other min file from assets.json

### DIFF
--- a/inc/services/assets.php
+++ b/inc/services/assets.php
@@ -161,6 +161,11 @@ class Assets implements Service{
 				break;
 		}
 
+		// Custom type
+		if ( ! empty( $assets[ $type ] ) ) {
+			$file = $assets[ $type ];
+		}
+
 		if ( empty( $file ) ) {
 			return false;
 		}


### PR DESCRIPTION
Permet de load un thème enfant par exemple : 

`$assets = \BEA\Theme\Framework\Framework::get_container()->get_service('assets' );`
`$file = $assets->get_min_file( 'app-child_theme.css' );`