### PR TITLE
feat (render) add Service 'Templates' 

### DIFF
--- a/inc/framework.php
+++ b/inc/framework.php
@@ -27,6 +27,7 @@ class Framework {
 		\BEA\Theme\Framework\Services\Acf::class,
 		\BEA\Theme\Framework\Services\Sidebar::class,
 		\BEA\Theme\Framework\Services\Menu::class,
+		\BEA\Theme\Framework\Services\Templates::class,
 
 		// Services as Tools
 		\BEA\Theme\Framework\Tools\Body_Class::class,

--- a/inc/services/templates.php
+++ b/inc/services/templates.php
@@ -6,12 +6,11 @@ use BEA\Theme\Framework\Service;
 use BEA\Theme\Framework\Service_Container;
 
 /**
- * Class Helpers
+ * Class Templates
  *
  * @package Beapi\Theme\Framework
  */
-class Templates implements Service {
-
+class Templates implements Service, TemplatesInterface {
 
 	/**
 	 * @param Service_Container $container
@@ -45,7 +44,7 @@ class Templates implements Service {
 			return false;
 		}
 
-		$path = apply_filters( 'BEA\Theme\Framework\Services', array( $tpl . '.php' ), $tpl, __NAMESPACE__ );
+		$path = apply_filters( 'BEA\Theme\Framework\Services\Templates', array( $tpl . '.php' ), $tpl, __NAMESPACE__ );
 
 		// Locate from the theme
 		$located = locate_template( $path, false, false );
@@ -176,27 +175,32 @@ class Templates implements Service {
 
 	public static function get_block( $block_name, array $args = [] ) {
 		if ( ! empty( $args ) ) {
-			self::render( 'components/blocks/' . $block_name, $args, true );
+			self::render( BLOCKS . $block_name, $args, true );
 		} else {
-			get_template_part( 'components/blocks/' . $block_name );
+			get_template_part( BLOCKS . $block_name );
 		}
 	}
 
 	public static function get_part( $part_name, $module, array $args = [] ) {
 		if ( ! empty( $args ) ) {
-			self::render( 'components/parts/' . $module . '/' . $part_name, $args, true );
+			self::render( PARTS . $module . '/' . $part_name, $args, true );
 		} else {
-			get_template_part( 'components/parts/' . $module . '/' . $part_name );
+			get_template_part( PARTS . $module . '/' . $part_name );
 		}
 	}
-
-	public static function get_hero( $hero_name, array $args = [] ) {
-		self::get_block( 'hero/' . $hero_name, $args, true );
-	}
-
-	public static function get_cards( $card_name, array $args = [] ) {
-		self::get_block( 'cards/' . $card_name, $args, true );
-	}
+	/**
+	 * example of optional helpers
+	 * @param string $loop
+	 * @param array $args
+	 */
+//
+//	public static function get_hero( $hero_name, array $args = [] ) {
+//		self::get_block( 'hero/' . $hero_name, $args, true );
+//	}
+//
+//	public static function get_cards( $card_name, array $args = [] ) {
+//		self::get_block( 'cards/' . $card_name, $args, true );
+//	}
 
 	public static function get_loop( string $loop, $args = [] ) {
 		if ( ! empty( $args ) ) {

--- a/inc/services/templates.php
+++ b/inc/services/templates.php
@@ -6,11 +6,12 @@ use BEA\Theme\Framework\Service;
 use BEA\Theme\Framework\Service_Container;
 
 /**
- * Class Templates
+ * Class Helpers
  *
  * @package Beapi\Theme\Framework
  */
-class Templates implements Service, TemplatesInterface {
+class Templates implements Service {
+
 
 	/**
 	 * @param Service_Container $container
@@ -44,7 +45,7 @@ class Templates implements Service, TemplatesInterface {
 			return false;
 		}
 
-		$path = apply_filters( 'BEA\Theme\Framework\Services\Templates', array( $tpl . '.php' ), $tpl, __NAMESPACE__ );
+		$path = apply_filters( 'BEA\Theme\Framework\Services', array( $tpl . '.php' ), $tpl, __NAMESPACE__ );
 
 		// Locate from the theme
 		$located = locate_template( $path, false, false );
@@ -175,32 +176,27 @@ class Templates implements Service, TemplatesInterface {
 
 	public static function get_block( $block_name, array $args = [] ) {
 		if ( ! empty( $args ) ) {
-			self::render( BLOCKS . $block_name, $args, true );
+			self::render( 'components/blocks/' . $block_name, $args, true );
 		} else {
-			get_template_part( BLOCKS . $block_name );
+			get_template_part( 'components/blocks/' . $block_name );
 		}
 	}
 
 	public static function get_part( $part_name, $module, array $args = [] ) {
 		if ( ! empty( $args ) ) {
-			self::render( PARTS . $module . '/' . $part_name, $args, true );
+			self::render( 'components/parts/' . $module . '/' . $part_name, $args, true );
 		} else {
-			get_template_part( PARTS . $module . '/' . $part_name );
+			get_template_part( 'components/parts/' . $module . '/' . $part_name );
 		}
 	}
-	/**
-	 * example of optional helpers
-	 * @param string $loop
-	 * @param array $args
-	 */
-//
-//	public static function get_hero( $hero_name, array $args = [] ) {
-//		self::get_block( 'hero/' . $hero_name, $args, true );
-//	}
-//
-//	public static function get_cards( $card_name, array $args = [] ) {
-//		self::get_block( 'cards/' . $card_name, $args, true );
-//	}
+
+	public static function get_hero( $hero_name, array $args = [] ) {
+		self::get_block( 'hero/' . $hero_name, $args, true );
+	}
+
+	public static function get_cards( $card_name, array $args = [] ) {
+		self::get_block( 'cards/' . $card_name, $args, true );
+	}
 
 	public static function get_loop( string $loop, $args = [] ) {
 		if ( ! empty( $args ) ) {

--- a/inc/services/templates.php
+++ b/inc/services/templates.php
@@ -45,7 +45,7 @@ class Templates implements Service {
 			return false;
 		}
 
-		$path = apply_filters( 'BEA\Theme\Framework\Services', array( $tpl . '.php' ), $tpl, __NAMESPACE__ );
+		$path = apply_filters( 'BEA\Theme\Framework\Services\Templates', array( $tpl . '.php' ), $tpl, __NAMESPACE__ );
 
 		// Locate from the theme
 		$located = locate_template( $path, false, false );
@@ -166,13 +166,6 @@ class Templates implements Service {
 	 * @param string $block_name filename
 	 * @param array $args arguments to pass
 	 */
-	public static function get_section( $block_name, array $args = [] ) {
-		self::get_block( 'sections/' . $block_name, $args );
-	}
-
-	public static function get_svg( $block_name, array $args = [] ) {
-		self::get_block( 'svg/' . $block_name, $args );
-	}
 
 	public static function get_block( $block_name, array $args = [] ) {
 		if ( ! empty( $args ) ) {
@@ -188,14 +181,6 @@ class Templates implements Service {
 		} else {
 			get_template_part( 'components/parts/' . $module . '/' . $part_name );
 		}
-	}
-
-	public static function get_hero( $hero_name, array $args = [] ) {
-		self::get_block( 'hero/' . $hero_name, $args, true );
-	}
-
-	public static function get_cards( $card_name, array $args = [] ) {
-		self::get_block( 'cards/' . $card_name, $args, true );
 	}
 
 	public static function get_loop( string $loop, $args = [] ) {

--- a/inc/services/templates.php
+++ b/inc/services/templates.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace BEA\Theme\Framework\Services;
+
+use BEA\Theme\Framework\Service;
+use BEA\Theme\Framework\Service_Container;
+
+/**
+ * Class Helpers
+ *
+ * @package Beapi\Theme\Framework
+ */
+class Templates implements Service {
+
+
+	/**
+	 * @param Service_Container $container
+	 */
+	public function register( Service_Container $container ) {
+	}
+
+	/**
+	 * @param Service_Container $container
+	 */
+	public function boot( Service_Container $container ) {
+
+	}
+
+	/**
+	 * @return string
+	 */
+	public function get_service_name() {
+		return 'templates';
+	}
+
+	/**
+	 * Locate template in the theme or plugin if needed
+	 *
+	 * @param string $tpl : the tpl name, add automatically .php at the end of the file
+	 *
+	 * @return bool|string
+	 */
+	public static function locate_template( $tpl ) {
+		if ( empty( $tpl ) ) {
+			return false;
+		}
+
+		$path = apply_filters( 'BEA\Theme\Framework\Services', array( $tpl . '.php' ), $tpl, __NAMESPACE__ );
+
+		// Locate from the theme
+		$located = locate_template( $path, false, false );
+
+		if ( ! empty( $located ) ) {
+			return $located;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Include the template given
+	 *
+	 * @param string $tpl : the template name to load
+	 *
+	 * @return bool
+	 */
+	public static function include_template( $tpl ) {
+		if ( empty( $tpl ) ) {
+			return false;
+		}
+
+		$tpl_path = self::locate_template( $tpl );
+		if ( false === $tpl_path ) {
+			return false;
+		}
+
+		include( $tpl_path );
+
+		return true;
+	}
+
+	/**
+	 * Load the template given and return a view to be render
+	 *
+	 * @param string $tpl : the template name to load
+	 *
+	 * @return \Closure|false
+	 */
+	public static function load_template( $tpl ) {
+		if ( empty( $tpl ) ) {
+			return false;
+		}
+
+		$tpl_path = self::locate_template( $tpl );
+		if ( false === $tpl_path ) {
+			return false;
+		}
+
+		/**
+		 * closure
+		 *
+		 * @param boolean $display return element or print it ?
+		 *
+		 * @return string element if display is false
+		 */
+		return function ( $data, $display = false ) use ( $tpl_path ) {
+			if ( ! is_array( $data ) ) {
+				$data = array( 'data' => $data );
+			}
+
+			extract( $data, EXTR_OVERWRITE );
+
+			if ( false === $display ) {
+				ob_start();
+				include $tpl_path;
+
+				return ob_get_clean();
+			} else {
+				include $tpl_path;
+
+				return true;
+			}
+
+		};
+	}
+
+	/**
+	 * Render a view
+	 *
+	 * @param string $tpl : the template's name
+	 * @param array $data : the template's data
+	 * @param boolean $display return element or print it ?
+	 *
+	 * @return string element if display is false
+	 */
+	public static function render( $tpl, $data = array(), $display = false ) {
+
+		$view = self::load_template( $tpl );
+
+		return $view ? $view( $data, $display ) : '';
+	}
+
+	/**
+	 *
+	 * load sample images (front-end like)
+	 *
+	 * @param $name filename
+	 * @param string $xclass custom css class (lazyload) by default
+	 * @param string $alt text alternative
+	 * @param string $wrapBefore html before image (<picture>) by default
+	 * @param string $wrapAfter html after image (</picture>) by default
+	 *
+	 * @return string html <img> rendered
+	 */
+	public static function get_sample_image( $name, $xclass = 'lazyload', $alt = '', $wrapBefore = '<picture>', $wrapAfter = '</picture>' ) {
+		return $wrapBefore . '<img class=" ' . $xclass . '" src="' . get_theme_file_uri( 'dist/assets/img/sample/' . $name ) . '" alt="' . $alt . '">' . $wrapAfter;
+	}
+
+	public static function the_sample_image( $name, $xclass = 'lazyload', $alt = '', $wrapBefore = '<picture>', $wrapAfter = '</picture>' ) {
+		echo self::get_sample_image( $name, $xclass, $alt, $wrapBefore, $wrapAfter );
+	}
+
+	/**
+	 * multiple methods to include files easily
+	 *
+	 * @param string $block_name filename
+	 * @param array $args arguments to pass
+	 */
+	public static function get_section( $block_name, array $args = [] ) {
+		self::get_block( 'sections/' . $block_name, $args );
+	}
+
+	public static function get_svg( $block_name, array $args = [] ) {
+		self::get_block( 'svg/' . $block_name, $args );
+	}
+
+	public static function get_block( $block_name, array $args = [] ) {
+		if ( ! empty( $args ) ) {
+			self::render( 'components/blocks/' . $block_name, $args, true );
+		} else {
+			get_template_part( 'components/blocks/' . $block_name );
+		}
+	}
+
+	public static function get_part( $part_name, $module, array $args = [] ) {
+		if ( ! empty( $args ) ) {
+			self::render( 'components/parts/' . $module . '/' . $part_name, $args, true );
+		} else {
+			get_template_part( 'components/parts/' . $module . '/' . $part_name );
+		}
+	}
+
+	public static function get_hero( $hero_name, array $args = [] ) {
+		self::get_block( 'hero/' . $hero_name, $args, true );
+	}
+
+	public static function get_cards( $card_name, array $args = [] ) {
+		self::get_block( 'cards/' . $card_name, $args, true );
+	}
+
+	public static function get_loop( string $loop, $args = [] ) {
+		if ( ! empty( $args ) ) {
+			self::render( 'components/loops/' . $loop, $args, true );
+		} else {
+			get_template_part( 'components/loops/' . $loop );
+		}
+	}
+}


### PR DESCRIPTION
The goal from this feature is to get closer to the Front-End developers way of writing and calling, so integration get's faster, so we will just replace their calls by ours.

### Update the `render()` function parameters
The function prints automatically the content, while sometimes we want to stock the results into a variable.
To not alternate the old behaviour of the method, i added an optional argument `$display` which is set to `true` by default.

### Create Service Templates with Helper methods to locate templates 👍 
- get_loop()
- get_cards()
- get_hero()
- get_part()
- get_block()
- get_svg()
- get_section()

### Add methods to load static images 
- get_sample_image()
- the_sample_image()

### Update render() method by adding a last argument _display_
the goal is to simplify the call and avoid `ob_start()` and `ob_get_clean()`.



