### PR TITLE
fix (mixins) : add missed placeholder prefix

### DIFF
--- a/src/scss/abstract/_mixins.scss
+++ b/src/scss/abstract/_mixins.scss
@@ -170,10 +170,10 @@
 
 // Customize placeholder
 @mixin placeholder {
-	$placeholders: ":-webkit-input" ":-moz" "-moz" "-ms-input";
+	$placeholders: ":placeholder", ":-webkit-input-placeholder" ":-moz-placeholder" "-moz-placeholder" "-ms-input-placeholder";
 
 	@each $placeholder in $placeholders {
-		&:#{$placeholder}-placeholder {
+		&:#{$placeholder} {
 			@content;
 		}
 	}


### PR DESCRIPTION
Il manquait le préfixe `::placeholder`.