### PR TITLE
fix (svg) - acf-svg-icon comptaibility - Do not force adding "icon-" …

### DIFF
--- a/inc/Services/Svg.php
+++ b/inc/Services/Svg.php
@@ -38,11 +38,12 @@ class Svg implements Service {
 	 * @return string
 	 */
 	public function get_the_icon( $icon_class, $additionnal_classes = [] ) {
-		$classes = [ 'icon', sprintf( 'icon-%s', $icon_class ) ];
-		$classes = array_merge( $classes, $additionnal_classes );
-		$classes = array_map( 'sanitize_html_class', $classes );
+		$icon_slug = sprintf( 'icon-%s', ltrim( $icon_class, 'icon-' ) );
+		$classes   = [ 'icon', $icon_slug ];
+		$classes   = array_merge( $classes, $additionnal_classes );
+		$classes   = array_map( 'sanitize_html_class', $classes );
 
-		return sprintf( '<svg class="%s" aria-hidden="true" focusable="false"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="%s#icon-%s"></use></svg>', implode( ' ', $classes ), \get_theme_file_uri( '/dist/assets/img/icons/icons.svg' ), $icon_class ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		return sprintf( '<svg class="%s" aria-hidden="true" focusable="false"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="%s#%s"></use></svg>', implode( ' ', $classes ), \get_theme_file_uri( '/dist/assets/img/icons/icons.svg' ), $icon_slug ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**


### PR DESCRIPTION
**Add `acf-svg-icon` plugin compatibility.**

Don't force adding `icon-` if it's already present.

**Result :**

```
the_icon('build'); // Works
the_icon('icon-build'); // Works with this change
```