### PR TITLE
feat (webpack) : set jquery as externals dependency

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -11,6 +11,9 @@ module.exports = {
     publicPath: '',
     assetModuleFilename: 'assets/[hash][ext][query]',
   },
+  externals: {
+    jquery: 'window.jQuery',
+  },
   module: {
     rules: [loaders.FontsLoader, loaders.ImagesLoader, loaders.JSLoader],
   },

--- a/src/js/classes/AccessibleMenu.js
+++ b/src/js/classes/AccessibleMenu.js
@@ -1,3 +1,4 @@
+import $ from 'jquery'
 import AbstractDomElement from './AbstractDomElement'
 import '../vendor/accessible-mega-menu'
 
@@ -17,10 +18,7 @@ class AccessibleMenu extends AbstractDomElement {
     const el = this._element
     const s = this._settings
 
-    ;(function ($) {
-      // Accesible toggle menu;
-      $(el).accessibleMegaMenu(s.options)
-    })(jQuery)
+    $(el).accessibleMegaMenu(s.options)
   }
 }
 


### PR DESCRIPTION
Permets de faire : 
```js
import $ from 'jquery'
```

à la place de 
```js
const $ = jQuery
```

OU

```js
;(function ($) {
  // do stuff
})(jQuery)
```