### PR TITLE
fix (gutenberg): let bottom spacing to add new blocks

### DIFF
--- a/src/scss/06-blocks/_gutenberg.scss
+++ b/src/scss/06-blocks/_gutenberg.scss
@@ -108,4 +108,12 @@
             margin-top: var(--spacing--block-1);
         }
     }
+
+    @include editor-only {
+        > * {
+            &:last-child {
+                margin-bottom: var(--spacing--block-1);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Sur l'éditeur, on souhaite laisser une marge inférieure sur le dernier bloc pour avoir la zone d'ajout d'un nouveau bloc qui apparait. Exemples : 

**Sans :**
![Capture d’écran 2022-06-24 à 15 02 50](https://user-images.githubusercontent.com/2543936/175541686-252dbc7a-a24a-4600-a88c-441602f7e2db.png)
**Avec :**
![Capture d’écran 2022-06-24 à 15 02 26](https://user-images.githubusercontent.com/2543936/175541707-21bcbac5-9f38-4fce-8d31-264048d62fdd.png)
