### PR TITLE
feat (variables): create variable for palette colors

### DIFF
--- a/src/scss/01-abstract/_variables.scss
+++ b/src/scss/01-abstract/_variables.scss
@@ -39,6 +39,28 @@ $color-primary: $color-yellow-500;
 $color-secondary: $color-grey-400;
 $color-text: $color-grey-900;
 
+// ----
+// Gutenberg palette
+// ----
+$palette: (
+    "primary": (
+        "color": $color-primary,
+        "isColorLight": true,
+    ),
+    "secondary": (
+        "color": $color-secondary,
+        "isColorLight": false,
+    ),
+    "dark": (
+        "color":  $color-dark,
+        "isColorLight": false,
+    ),
+    "light": (
+        "color":  $color-light,
+        "isColorLight": true,
+    ),
+);
+
 // ==========
 // Sizes
 // ==========

--- a/src/scss/04-utilities/_palette.scss
+++ b/src/scss/04-utilities/_palette.scss
@@ -1,15 +1,11 @@
-@each $name, $color
-    in (
-        "primary": $color-primary,
-        "secondary": $color-secondary,
-        "dark" : $color-dark,
-        "light" : $color-light,
-    ) {
+@use "sass:map";
+
+@each $name, $colors in $palette {
     .has-#{$name}-color {
-        color: #{$color};
+        color: map.get($colors, color);
     }
 
     .has-#{$name}-background-color {
-        background-color: #{$color};
+        background-color: map.get($colors, color);
     }
 }


### PR DESCRIPTION
Dans cette PR, l'idée est de mettre les couleurs déclarés dans l'éditeur Gutenberg dans une variable SCSS et de lui assigner un nouveau paramètre `isColorLight` qui pourrait servir à déterminer la bonne couleur du texte à utiliser sur un composant Gutenberg. Exemple sur un composant `core/button` : 

`_variables.scss`
```scss
// ----
// Gutenberg palette
// ----
$palette: (
    "dark": (
        "color": $color-dark,
        "isColorLight": false,
    ),
    "blue": (
        "color": $color-blue-600,
        "isColorLight": false,
    ),
    "grey": (
        "color": #777574,
        "isColorLight": false,
    ),
    "grey-light": (
        "color": #f4f4f4,
        "isColorLight": true,
    ),
    "light": (
        "color": $color-light,
        "isColorLight": true,
    ),
);
```

`_buttons.scss`
```scss
@use "sass:color";
@use "sass:map";

.wp-block {
    // ----
    // container
    // ----
    &-buttons {
        gap: 25px;
    }

    // ----
    // button
    // ----
    &-button {
        .wp-block-button__link {
            @extend %button-block;

            @each $name, $colors in $palette {
                &.has-#{$name}-background-color {
                    background-color: map.get($colors, color);

                    @if map.get($colors, isColorLight) == true {
                        color: $color-primary !important;
                    } @else {
                        color: $color-light !important;
                    }
                }
            }
        }
    }
}

```