### PR TITLE
Chore/webpack manifest plugin

### DIFF
--- a/config/plugins.js
+++ b/config/plugins.js
@@ -36,7 +36,6 @@ module.exports = {
       plugins.push(
         new WebpackManifestPlugin({
           fileName: 'assets.json',
-          filter: (file) => !file.isAsset,
         }),
         new MiniCssExtractPlugin({
           filename: '[name].[contenthash:8].min.css',

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "webpack": "^5.35.0",
     "webpack-bundle-analyzer": "^4.4.1",
     "webpack-cli": "^4.6.0",
-    "webpack-manifest-plugin": "^3.1.1",
+    "webpack-manifest-plugin": "5.0.0",
     "webpack-merge": "^5.7.3",
     "webpackbar": "^5.0.0-3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4701,10 +4701,10 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-oneloop.js@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/oneloop.js/-/oneloop.js-3.0.0.tgz#a335e4ad586100fcd7675758d531be3263995170"
-  integrity sha512-hr4piTW10sY61AN7CE1XiCJjBHb7uYxyvCgXQoCCxQUMegJXIztoHOfR77cCOCJT4iI3Bv2VDBKKPXuaIXFB2Q==
+oneloop.js@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/oneloop.js/-/oneloop.js-4.0.1.tgz#c545bdcb7b29c24d2b0d626bc3187fd68a5fca21"
+  integrity sha512-BpsX0zOjHdrcBE5WfMr723k80ZlFiB6za+rsPyDo4zcA2f53Qp4ySze9idtcRCTO4h9NCPzxkCaaz7NAsdGEtA==
 
 onetime@^5.1.0, onetime@^5.1.2:
   version "5.1.2"
@@ -7445,10 +7445,10 @@ webpack-cli@^4.6.0:
     v8-compile-cache "^2.2.0"
     webpack-merge "^5.7.3"
 
-webpack-manifest-plugin@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/webpack-manifest-plugin/-/webpack-manifest-plugin-3.1.1.tgz#d4c57ef70e0641f754dd005cb5ba7ca5601ac9d3"
-  integrity sha512-r3vL8BBNVtyeNbaFwDQoOWqBd0Gp/Tbzo8Q3YGZDV+IG77gsB9VZry5XKKbfFNFHSmwW+f1z4/w2XPt6wBZJYg==
+webpack-manifest-plugin@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/webpack-manifest-plugin/-/webpack-manifest-plugin-5.0.0.tgz#084246c1f295d1b3222d36e955546433ca8df803"
+  integrity sha512-8RQfMAdc5Uw3QbCQ/CBV/AXqOR8mt03B6GJmRbhWopE8GzRfEpn+k0ZuWywxW+5QZsffhmFDY1J6ohqJo+eMuw==
   dependencies:
     tapable "^2.0.0"
     webpack-sources "^2.2.0"


### PR DESCRIPTION
- Mise à jour du plugin `webpack-manifest-plugin` en 5.0.0
- Suppression du filtre pour afficher dans les assets dans le manifest JSON