### PR TITLE
feat (scss): add function get gutter width

### DIFF
--- a/src/scss/02-tools/_f-get-gutter-width.scss
+++ b/src/scss/02-tools/_f-get-gutter-width.scss
@@ -1,0 +1,15 @@
+@use "sass:map";
+
+/**
+ * Get Gutter width
+ *
+ * get the value of gutter according to the preset
+ */
+
+@function get-gutter($preset: d) {
+    @return map.get(map.get($column-preset, $preset), gutter-width);
+}
+
+@function get-gutter-width($preset: d) {
+    @return get-gutter($preset) * 1px;
+}

--- a/src/scss/02-tools/tools.scss
+++ b/src/scss/02-tools/tools.scss
@@ -8,6 +8,7 @@
 @import "./f-context-selector";
 @import "./f-easings";
 @import "./f-em";
+@import "./f-get-gutter-width";
 @import "./f-get-svg-url";
 @import "./f-strip-units";
 @import "./f-to-number";


### PR DESCRIPTION
Permet de récupérer la valeur du gutter depuis la variable `$column-preset` en fonction du preset.

```scss
@use "sass:map";

/**
 * Get Gutter width
 *
 * get the value of gutter according to the preset
 */

@function get-gutter($preset: d) {
    @return map.get(map.get($column-preset, $preset), gutter-width);
}

@function get-gutter-width($preset: d) {
    @return get-gutter($preset) * 1px;
}
```

## Exemple d'utilisation

```scss
div {
    display: grid;
    grid-template-columns: repeat(2, 1fr);
    row-gap: 24px;
    column-gap: get-gutter-width(t);
}
```