### PR TITLE
feat (scss): add tool mixin container query

### DIFF
--- a/src/scss/02-tools/_m-container-query.scss
+++ b/src/scss/02-tools/_m-container-query.scss
@@ -1,0 +1,41 @@
+@use "sass:map";
+
+/**
+ * Container Query
+ *
+ * examples :
+ *
+ *      @include container-query(sm, md, name) { ... }
+ *          return @container name (min-width: 768px) and (max-width: 1024px) { ... }
+ *
+ *      @include container-query(sm, max, name) { ... }
+ *          return @container (max-width: 767px) { ... }
+ *
+ *      @include container-query(sm, min, name) { ... }
+ *          return @container name (min-width: 768px) { ... }
+ *
+ */
+
+@mixin container-query($breakpoint, $min-or-max-or-breakpoint: min, $container-name: "") {
+    $font-size: 16px; // don't use em function whitout param, $font-size-base can be modified
+
+    @if (type-of(map.get($breakpoints, $min-or-max-or-breakpoint)) == "number") {
+
+        @container #{$container-name} (min-width: #{em(map.get($breakpoints, $breakpoint), $font-size)}) and (max-width: #{em(map.get($breakpoints, $min-or-max-or-breakpoint) - 1, $font-size)}) {
+
+            @content;
+        }
+    } @else if ($min-or-max-or-breakpoint == max) {
+
+        @container #{$container-name} (max-width: #{em(map.get($breakpoints, $breakpoint) - 1, $font-size)}) {
+
+            @content;
+        }
+    } @else {
+
+        @container #{$container-name} (min-width: #{em(map.get($breakpoints, $breakpoint), $font-size)}) {
+
+            @content;
+        }
+    }
+}

--- a/src/scss/02-tools/tools.scss
+++ b/src/scss/02-tools/tools.scss
@@ -19,6 +19,7 @@
 @import "./m-checkbox-custom";
 @import "./m-clearflex";
 @import "./m-container";
+@import "./m-container-query";
 @import "./m-declare-font-face";
 @import "./m-editor-only";
 @import "./m-heading";


### PR DESCRIPTION
## Add Container Query mixin

### Support 

https://caniuse.com/css-container-queries

### Example 
```style.scss
.card {
    container-type: inline-size;
    container-name: card;
}

.card__title {
    color: blue;
}

@include container-query(600px, min, card) {
    .card__title {
        color: red;
    }
}
```

```style.css
.card {
    container-type: inline-size;
    container-name: card;
}

.card__title {
    color: blue;
}

@container card (min-width: 600px) {
    .card__title {
        color: red;
    }
}
```

À voir si on ne peut pas simplifier la mixin ou renommer l'actuel mixin `container`