### PR TITLE
Reset inner margin in wp-block-group

### DIFF
--- a/src/scss/06-blocks/core/_group.scss
+++ b/src/scss/06-blocks/core/_group.scss
@@ -1,5 +1,16 @@
 .wp-block-group {
+    $el: &;
+
     display: flow-root;
+
+    &--no-inner-margin {
+        #{$el}__inner-container {
+            > * {
+                margin-top: 0;
+                margin-bottom: 0;
+            }
+        }
+    }
 }
 
 @include editor-only {


### PR DESCRIPTION
Pour reset les marges à l'intérieur d'un groupe -> à l'aide d'une class

Problème qui revient sur chaque projets à la création des patterns, quand on a un groupe ça rajoute automatiquement des marges sur chaque éléments à l'intérieur et il faut constamment les reset ou les modifier pour chaque pattern.

Exemple pattern : 
`<!-- wp:group {"className":"wp-block-group--mon-pattern wp-block-group--no-inner-margin"} -->`