### PR TITLE
core columns -> add stroke style + tablet responsive

### DIFF
--- a/inc/Services/Editor.php
+++ b/inc/Services/Editor.php
@@ -181,7 +181,16 @@ class Editor implements Service {
 	 */
 
 	private function register_custom_block_styles() {
-		//button
+		// Columns
+		register_block_style(
+			'core/columns',
+			[
+				'name'  => 'stroke',
+				'label' => __( 'Stroke', 'beapi-frontend-framework' ),
+			]
+		);
+
+		// Buttons
 		//      register_block_style(
 		//          'core/button',
 		//          [

--- a/inc/Services/Editor.php
+++ b/inc/Services/Editor.php
@@ -181,15 +181,6 @@ class Editor implements Service {
 	 */
 
 	private function register_custom_block_styles() {
-		// Columns
-		register_block_style(
-			'core/columns',
-			[
-				'name'  => 'stroke',
-				'label' => __( 'Stroke', 'beapi-frontend-framework' ),
-			]
-		);
-
 		// Buttons
 		//      register_block_style(
 		//          'core/button',

--- a/src/scss/01-abstract/_variables.scss
+++ b/src/scss/01-abstract/_variables.scss
@@ -106,6 +106,7 @@ $breakpoints: (
     sm: 768,
     admin-bar: 784,
     md: 1024,
+    mdl: 1200,
     lg: $container-wide + $external-gutter,
 );
 // /!\ WARNING: If you use a breakpoint of 1280px, it causes a bug under Window Edge with a device pixel ratio higher than 1. Prefer to use the value 1279px.

--- a/src/scss/06-blocks/core/_columns.scss
+++ b/src/scss/06-blocks/core/_columns.scss
@@ -1,43 +1,43 @@
 .wp-block-columns {
-    &:not(.alignwide):not(.alignfull) {
-        clear: both;
-    }
+    @include breakpoints(sm, mdl) {
+        flex-wrap: wrap !important;
 
-    @include style-only {
-        .wp-block-column {
-            > * {
-                &:first-child {
-                    margin-top: 0;
-                }
-
-                &:last-child {
-                    margin-bottom: 0;
-                }
+        &.is-style-stroke {
+            .wp-block-column {
+                flex-basis: calc(50% - #{get-gutter-width()}) !important;
             }
+        }
 
-            &:last-child {
-                margin-bottom: 0;
-            }
-
-            @include breakpoints(sm) {
-                &:not(:first-child) {
-                    margin-left: column(t, 0, 1);
-                }
-            }
-
-            @include breakpoints(md) {
-                &:not(:first-child) {
-                    margin-left: column(0, 1);
-                }
+        &:not(.is-style-stroke) { // For override the WP style at 782px
+            .wp-block-column {
+                flex-basis: calc(50% - #{get-gutter-width() * .5}) !important;
+                flex-grow: 0 !important;
             }
         }
     }
 
-    @include editor-only {
-        .wp-block,
-        .wp-block-column {
-            // Allow Gutenberg to set the width of a block that lives inside the columns block.
-            max-width: inherit;
+    @include breakpoints(sm) {
+        gap: get-gutter-width() !important;
+
+        &.is-style-stroke {
+            gap: get-gutter-width() * 2 !important;
+            overflow: hidden;
+
+            .wp-block-column {
+                position: relative;
+
+                &::after {
+                    position: absolute;
+                    top: 0;
+                    right: -#{get-gutter-width()};
+                    left: inherit;
+                    width: 1px;
+                    height: 100%;
+                    content: "";
+                    background: $color-grey-200;
+                    opacity: 1;
+                }
+            }
         }
     }
 }

--- a/src/scss/06-blocks/core/_columns.scss
+++ b/src/scss/06-blocks/core/_columns.scss
@@ -24,18 +24,20 @@
             overflow: hidden;
 
             .wp-block-column {
-                position: relative;
+                &:not(:empty) {
+                    position: relative;
 
-                &::after {
-                    position: absolute;
-                    top: 0;
-                    right: -#{get-gutter-width()};
-                    left: inherit;
-                    width: 1px;
-                    height: 100%;
-                    content: "";
-                    background: $color-grey-200;
-                    opacity: 1;
+                    &::after {
+                        position: absolute;
+                        top: 0;
+                        right: -#{get-gutter-width()};
+                        left: inherit;
+                        width: 1px;
+                        height: 100%;
+                        content: "";
+                        background: $color-grey-200;
+                        opacity: 1;
+                    }
                 }
             }
         }

--- a/src/scss/06-blocks/core/_columns.scss
+++ b/src/scss/06-blocks/core/_columns.scss
@@ -1,43 +1,22 @@
 .wp-block-columns {
-    @include breakpoints(sm, mdl) {
-        flex-wrap: wrap !important;
+    gap: get-gutter-width() !important;
 
-        &.is-style-stroke {
-            .wp-block-column {
-                flex-basis: calc(50% - #{get-gutter-width()}) !important;
+    &:not(.is-not-stacked-on-mobile) {
+        .wp-block-column {
+            margin-left: 0 !important;
+
+            &:not(:only-child) {
+                flex-basis: 100% !important;
             }
         }
 
-        &:not(.is-style-stroke) { // For override the WP style at 782px
-            .wp-block-column {
-                flex-basis: calc(50% - #{get-gutter-width() * .5}) !important;
-                flex-grow: 0 !important;
-            }
-        }
-    }
-
-    @include breakpoints(sm) {
-        gap: get-gutter-width() !important;
-
-        &.is-style-stroke {
-            gap: get-gutter-width() * 2 !important;
-            overflow: hidden;
+        @include breakpoints(sm, mdl) {
+            flex-wrap: wrap !important;
 
             .wp-block-column {
-                &:not(:empty) {
-                    position: relative;
-
-                    &::after {
-                        position: absolute;
-                        top: 0;
-                        right: -#{get-gutter-width()};
-                        left: inherit;
-                        width: 1px;
-                        height: 100%;
-                        content: "";
-                        background: $color-grey-200;
-                        opacity: 1;
-                    }
+                &:not(:only-child) {
+                    flex-basis: calc(50% - #{get-gutter-width() * .5}) !important;
+                    flex-grow: 0 !important;
                 }
             }
         }


### PR DESCRIPTION
Récurrent sur les projets d'avoir des colonnes avec des bordures entre chaque colonnes.

**- Ajout d'un style "Stroke" pour pouvoir avoir des bordures entre les colonnes.**

**- Gestion responsive plus adaptée que WordPress (car de base il n'y a pas de règle vraiment adaptée) -> On passe en 2 colonnes entre 768px et 1199px et 1 colonne en dessous de 768px**

**Exemple natif WordPress** : on a une grille de 4 colonnes, on reste en 4 colonnes jusqu'à 782px, donc ça passe pas, puis ensuite 1 colonne en dessous de 782px donc trop grand sur une tablette portrait 768px)

**Exemple avec les modifs de la PR** : on a une grille de 4 colonnes, on reste en 4 colonnes jusqu'à 1200px, on passe en 2 colonnes jusqu'à 768px puis 1 colonne en dessous

Vu avec @ptesei à l'utilisation sur ICC