### PR TITLE
custom checkbox/radio complianz fix

### DIFF
--- a/src/scss/03-base/_forms.scss
+++ b/src/scss/03-base/_forms.scss
@@ -56,6 +56,17 @@ select {
 
 input[type="checkbox"],
 input[type="radio"] {
+    @include checkbox-custom;
+
+    &:checked {
+        @include checkbox-custom-checked;
+    }
+
+    /*
+    --------------------
+    For complianz plugin
+    --------------------
+
     *:not(.cmplz-banner-checkbox) > & {
         @include checkbox-custom;
 
@@ -63,12 +74,21 @@ input[type="radio"] {
             @include checkbox-custom-checked;
         }
     }
+    */
 }
 
 input[type="radio"] {
+    @include radio-custom(true);
+
+    /*
+    --------------------
+    For complianz plugin
+    --------------------
+
     *:not(.cmplz-banner-checkbox) > & {
         @include radio-custom(true);
     }
+    */
 }
 
 input[type="submit"] {

--- a/src/scss/03-base/_forms.scss
+++ b/src/scss/03-base/_forms.scss
@@ -56,15 +56,19 @@ select {
 
 input[type="checkbox"],
 input[type="radio"] {
-    @include checkbox-custom;
+    *:not(.cmplz-banner-checkbox) > & {
+        @include checkbox-custom;
 
-    &:checked {
-        @include checkbox-custom-checked;
+        &:checked {
+            @include checkbox-custom-checked;
+        }
     }
 }
 
 input[type="radio"] {
-    @include radio-custom;
+    *:not(.cmplz-banner-checkbox) > & {
+        @include radio-custom(true);
+    }
 }
 
 input[type="submit"] {


### PR DESCRIPTION
Pour corriger un conflit sur les checkbox/radio custom des settings de la cookie bar de complianz qu'on utilise sur les projets.

Utile ? ou reporter la modif sur chaque projet à chaque fois ?