### PR TITLE
feat (mixins): add mixin line-clamp

### DIFF
--- a/src/scss/02-tools/_m-line-clamp.scss
+++ b/src/scss/02-tools/_m-line-clamp.scss
@@ -6,7 +6,6 @@
 @mixin line-clamp($lines: 2) {
     display: -webkit-box;
     overflow: hidden;
-    color: $color-light;
     -webkit-line-clamp: #{$lines};
     -webkit-box-orient: vertical;
 }

--- a/src/scss/02-tools/_m-line-clamp.scss
+++ b/src/scss/02-tools/_m-line-clamp.scss
@@ -1,0 +1,12 @@
+/// Truncates text at a specific number of lines.
+/// https://css-tricks.com/almanac/properties/l/line-clamp/
+///
+/// @param {number} $lines
+///   The number of lines for the text.
+@mixin line-clamp($lines: 2) {
+    display: -webkit-box;
+    overflow: hidden;
+    color: $color-light;
+    -webkit-line-clamp: #{$lines};
+    -webkit-box-orient: vertical;
+}

--- a/src/scss/02-tools/tools.scss
+++ b/src/scss/02-tools/tools.scss
@@ -24,6 +24,7 @@
 @import "./m-editor-only";
 @import "./m-heading";
 @import "./m-hover";
+@import "./m-line-clamp";
 @import "./m-placeholder-media";
 @import "./m-radio-custom";
 @import "./m-row-fullwidth";


### PR DESCRIPTION
# Ajout d'une mixin pour tronquer des textes avec plusieurs lignes.

## Usage

```scss
.card {
    &__title {
        @include line-clamp(3);
    }
}
```

Ouput : 
```css
.card__title {
    display: -webkit-box;
    overflow: hidden;
    -webkit-line-clamp: 3;
    -webkit-box-orient: vertical;
}
```

Voir https://css-tricks.com/almanac/properties/l/line-clamp/