### PR TITLE
refactor (admin-bar): apply var admin bar for body class admin-bar

### DIFF
--- a/src/scss/03-base/_variables-css.scss
+++ b/src/scss/03-base/_variables-css.scss
@@ -41,7 +41,7 @@
     /*
      * Admin bar
      */
-    --wp-admin-bar-height: 46px;
+    --wp-admin-bar-height: 0;
 
     /*
      * Alignments breakpoints
@@ -60,17 +60,6 @@
      */
     @include reduced-motion {
         --speed: 0s;
-    }
-
-    /*
-     * Global breakpoints
-     */
-
-    @include breakpoints(admin-bar) {
-        /*
-         * Admin bar
-         */
-        --wp-admin-bar-height: 32px;
     }
 
     @include breakpoints(md) {

--- a/src/scss/09-templates/_admin-bar.scss
+++ b/src/scss/09-templates/_admin-bar.scss
@@ -1,0 +1,16 @@
+.admin-bar {
+    /*
+     * Admin bar
+     */
+    --wp-admin-bar-height: 46px;
+
+    /*
+     * Global breakpoints
+     */
+    @include breakpoints(admin-bar) {
+        /*
+         * Admin bar
+         */
+        --wp-admin-bar-height: 32px;
+    }
+}

--- a/src/scss/09-templates/templates.scss
+++ b/src/scss/09-templates/templates.scss
@@ -1,3 +1,4 @@
 @import "./404";
+@import "./admin-bar";
 @import "./home";
 @import "./default";


### PR DESCRIPTION
Par défault `--wp-admin-bar-height: 0;`, mais dans `.admin-bar` on a : 

```scss
.admin-bar {
    /*
     * Admin bar
     */
    --wp-admin-bar-height: 46px;

    /*
     * Global breakpoints
     */
    @include breakpoints(admin-bar) {
        /*
         * Admin bar
         */
        --wp-admin-bar-height: 32px;
    }
}

```