### PR TITLE
feat (mixins): improve hover mixin

### DIFF
--- a/src/scss/02-tools/_m-hover.scss
+++ b/src/scss/02-tools/_m-hover.scss
@@ -8,10 +8,10 @@
     $selectors: "&:hover", "&:active", "&:focus";
 
     @if ($additionalSelectors) {
-        @if (type-of($additional-selectors) == "string") {
+        @if (type-of($additionalSelectors) == "string") {
             $selectors: $selectors "," $additionalSelectors;
         }
-        @else if (type-of($additional-selectors) == "list") {
+        @else if (type-of($additionalSelectors) == "list") {
             $selectors: list.join($selectors, $additionalSelectors, comma);
         }
     }

--- a/src/scss/02-tools/_m-hover.scss
+++ b/src/scss/02-tools/_m-hover.scss
@@ -2,10 +2,19 @@
 
 /// Add active, focus and hover pseudo selectors to element
 ///
-/// @param {list} $additionalSelectors
+/// @param {string||list} $additionalSelectors
 ///   List of additional selectors
-@mixin hover($additionalSelectors: ()) {
-    $selectors: list.join(("&:hover", "&:active", "&:focus"), $additionalSelectors, comma);
+@mixin hover($additionalSelectors: null) {
+    $selectors: "&:hover", "&:active", "&:focus";
+
+    @if ($additionalSelectors) {
+        @if (type-of($additional-selectors) == "string") {
+            $selectors: $selectors "," $additionalSelectors;
+        }
+        @else if (type-of($additional-selectors) == "list") {
+            $selectors: list.join($selectors, $additionalSelectors, comma);
+        }
+    }
 
     #{$selectors} {
         @content;

--- a/src/scss/02-tools/_m-hover.scss
+++ b/src/scss/02-tools/_m-hover.scss
@@ -1,13 +1,13 @@
-/**
- * Hover
- *
- *          Hover Active Focus pseudo selector mixin
- */
+@use "sass:list";
 
-@mixin hover {
-    &:hover,
-    &:active,
-    &:focus {
+/// Add active, focus and hover pseudo selectors to element
+///
+/// @param {list} $additionalSelectors
+///   List of additional selectors
+@mixin hover($additionalSelectors: ()) {
+    $selectors: list.join(("&:hover", "&:active", "&:focus"), $additionalSelectors, comma);
+
+    #{$selectors} {
         @content;
     }
 }


### PR DESCRIPTION
## Add additional selectors parameter.

### Before
```scss
/**
 * Hover
 *
 *          Hover Active Focus pseudo selector mixin
 */

@mixin hover {
    &:hover,
    &:active,
    &:focus {
        @content;
    }
}

```

### Now
```scss
@use "sass:list";

/// Add active, focus and hover pseudo selectors to element
///
/// @param {list} $additionalSelectors
///   List of additional selectors
@mixin hover($additionalSelectors: ()) {
    $selectors: list.join(("&:hover", "&:active", "&:focus"), $additionalSelectors, comma);

    #{$selectors} {
        @content;
    }
}

```

### Usage

#### Input
```scss
    a {
        @include hover(("&#foo", "&.bar")) {
            color: $color-primary;
            background-color: $color-dark;
        }
    }
```

#### Output
```css
a:active,
a:focus,
a:hover,
a#foo,
a.bar {
    color: #ff0;
    background-color: #000;
}
```