### PR TITLE
fix (webpack) : handle production dynamic import

### DIFF
--- a/inc/Services/Theme.php
+++ b/inc/Services/Theme.php
@@ -18,6 +18,9 @@ class Theme implements Service {
 	 */
 	public function boot( Service_Container $container ): void {
 		$this->after_setup_theme();
+
+		// expose theme infos
+		add_action( 'wp', [ $this, 'expose_theme_infos' ], 0 );
 	}
 
 	/**
@@ -73,5 +76,23 @@ class Theme implements Service {
 	private function i18n(): void {
 		// Load theme texdomain
 		load_theme_textdomain( 'framework-textdomain', \get_theme_file_path( '/languages' ) );
+	}
+
+	/**
+	 * Expose current theme infos
+	 */
+	public function expose_theme_infos():void {
+		if ( is_admin() ) {
+			return;
+		}
+
+		wp_register_script( 'theme-infos', '', [], null, false ); // phpcs:ignore
+		wp_enqueue_script( 'theme-infos' );
+
+		$json = [
+			'templateDirectoryUri' => get_template_directory_uri(),
+		];
+
+		wp_add_inline_script( 'theme-infos', 'window.themeInfos = ' . wp_json_encode( $json ) );
 	}
 }

--- a/inc/Services/Theme.php
+++ b/inc/Services/Theme.php
@@ -90,7 +90,8 @@ class Theme implements Service {
 		wp_enqueue_script( 'theme-infos' );
 
 		$json = [
-			'templateDirectoryUri' => get_template_directory_uri(),
+			'templateDirectoryUri'   => get_template_directory_uri(),
+			'stylesheetDirectoryUri' => get_stylesheet_directory_uri(),
 		];
 
 		wp_add_inline_script( 'theme-infos', 'window.themeInfos = ' . wp_json_encode( $json ) );

--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -1,3 +1,6 @@
+/* eslint-disable-next-line */
+__webpack_public_path__ = window.themeInfos.templateDirectoryUri + '/dist/'; // webpack right public path for dynamic import
+
 import lazySizes from 'lazysizes'
 import 'lazysizes/plugins/native-loading/ls.native-loading'
 import 'lazysizes/plugins/object-fit/ls.object-fit'

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,3 +1,6 @@
+/* eslint-disable-next-line */
+__webpack_public_path__ = window.themeInfos.templateDirectoryUri + '/dist/'; // webpack right public path for dynamic import
+
 import lazySizes from 'lazysizes'
 import 'lazysizes/plugins/native-loading/ls.native-loading'
 import 'lazysizes/plugins/object-fit/ls.object-fit'


### PR DESCRIPTION
Webpack gère le chargement dynamique des node_modules différemment entre le mode développement et la production.

En production, le paramètre `publicPath` du fichier webpack.common.js doit être renseigné pour fournir un path complet vers les ressources dynamiques. Ce qui est incompatible avec le chargement des ressources par le bff. 

Pour contourner le problème, il a été ajouté une variable global javascript themeInfos (qui à terme pourrait contenir d’autres informations) qui contient la valeur `template_directory_uri` afin  de définir dynamiquement la valeur de la variable `__webpack_public_path__`