### PR TITLE
AbstractDomElement - nouvelle version

### DIFF
--- a/src/js/classes/AbstractDomElement.js
+++ b/src/js/classes/AbstractDomElement.js
@@ -1,131 +1,223 @@
-/*
-  How to use :
-
-  class MyClass extends AbstractDomElement {
-    constructor(element, options) {
-      const instance = super(element, options)
-
-      // avoid double init :
-      if (!instance.isNewInstance()) {
-        return instance
-      }
-
-      // init of MyClass
-      // ...
-    }
-  }
-
-  MyClass.defaults = {
-
-  }
-
-  MyClass.preset = {
-    '.selector' : {this object will be extended with defaults options}
-  }
-
-  // loop on each preset
-  MyClass.initFromPreset()
-
-*/
-
-import extend from '../utils/extend.js'
+import extend from '../utils/extend'
 
 class AbstractDomElement {
+  /**
+   * AbstractDomElement
+   * @constructor
+   * @version 3.0.0
+   * @param {NodeElement} element
+   * @param {Object} options
+   * @return {Object} this
+   */
   constructor(element, options) {
-    let oldInstance
+    const childClass = this.constructor
+    const oldInstance = childClass.getInstance(element)
 
-    // provide an explicit spaceName to prevent conflict after minification
-    // MaClass.nameSpace = 'MaClass'
-    this.constructor.nameSpace = this.constructor.nameSpace || this.constructor.name
-    const nameSpace = this.constructor.nameSpace
-
-    // if no spacename beapi, create it - avoid futur test
-    if (!element.beapi) {
-      element.beapi = {}
+    // if new AbstractDomElement() is called
+    if (childClass === AbstractDomElement) {
+      console.error("[AbstractDomElement] : AbstractDomElement can't be instancied directly")
     }
 
-    oldInstance = element.beapi[nameSpace]
+    // if instances static property has not been set on child class
+    if (!childClass.instances) {
+      childClass.instances = []
+    }
 
+    // if element already been initialized, return old instance
     if (oldInstance) {
-      console.warn(
-        '[AbstractDomElement] more than 1 class is initialised with the same name space on :',
-        element,
-        oldInstance
-      )
-      oldInstance._isNewInstance = false
+      console.warn('[' + childClass.name + '] : Is already instancied on : ', element)
+      this._isNewInstance = false
       return oldInstance
     }
 
+    // add instance to child class instances property
+    childClass.instances.push(this)
+
     this._element = element
-    this._settings = extend(true, {}, this.constructor.defaults, options)
-    this._element.beapi[nameSpace] = this
     this._isNewInstance = true
+    this._settings = buildSettings(childClass, options)
+
+    if (this._settings.autoRegisterChildren) {
+      this.registerChildren()
+    }
+
+    if (this._settings.autoInit) {
+      this.init()
+    }
   }
 
+  /**
+   * init : the purpose of this method is to be overrided in child class
+   * @abstract
+   * @return {Object} this
+   */
+  init() {
+    return this
+  }
+
+  /**
+   * isNewInstance : tell if element has been instancied more than once
+   * @return {Boolean}
+   */
   isNewInstance() {
     return this._isNewInstance
   }
 
-  destroy() {
-    this._element.beapi[this.constructor.nameSpace] = undefined
-    return this
+  /**
+   * getElement : get the element given at the class initialisation
+   * @return {NodeElement}
+   */
+  getElement() {
+    return this._element
   }
 
-  static init(element, options) {
-    foreach(element, (el) => {
-      new this(el, options)
-    })
+  /**
+   * registerChildren : register elements matching selectors options
+   * @return {Object} this
+   */
+  registerChildren() {
+    const selectors = this._settings.selectors
 
-    return this
-  }
-
-  static hasInstance(element) {
-    const el = getDomElement(element)
-    return el && el.beapi && !!el.beapi[this.nameSpace]
-  }
-
-  static getInstance(element) {
-    const el = getDomElement(element)
-    return el && el.beapi ? el.beapi[this.nameSpace] : undefined
-  }
-
-  static destroy(element) {
-    this.foreach(element, (el) => {
-      if (el.beapi && el.beapi[this.nameSpace]) {
-        el.beapi[this.nameSpace].destroy()
-      }
-    })
-
-    return this
-  }
-
-  static foreach(element, callback) {
-    foreach(element, (el) => {
-      if (el.beapi && el.beapi[this.nameSpace]) {
-        callback(el)
-      }
-    })
-
-    return this
-  }
-
-  static initFromPreset() {
-    const preset = this.preset
-    let selector
-
-    for (selector in preset) {
-      this.init(selector, preset[selector])
+    for (let name in selectors) {
+      this['_' + name] = this.find(selectors[name])
     }
 
     return this
   }
 
-  static destroyFromPreset() {
-    const preset = this.preset
-    let selector
+  /**
+   * find : shortcut for querySelectorAll inside element
+   * @return {NodeList}
+   */
+  find(selector) {
+    return this._element.querySelectorAll(selector)
+  }
 
-    for (selector in preset) {
-      this.destroy(selector)
+  /**
+   * destroy : remove instance from child class
+   * @return {Undefined}
+   */
+  destroy() {
+    const childClass = this.constructor
+    childClass.instances.splice(childClass.instances.indexOf(this), 1)
+  }
+
+  /**
+   * init
+   * @return {Object} this
+   */
+  static init(targets, options) {
+    const presets = this.presets
+    const argsLength = arguments.length
+
+    if (argsLength === 0) {
+      if (this.presets) {
+        for (let selector in presets) {
+          this.init(selector, presets[selector])
+        }
+      }
+    } else {
+      if (!options && typeof targets === 'string' && presets && presets[targets]) {
+        options = presets[targets]
+      }
+
+      const elements = getDomElements(targets)
+
+      for (let i = 0; i < elements.length; i++) {
+        new this(elements[i], options)
+      }
+    }
+
+    return this
+  }
+
+  /**
+   * hasInstance
+   * @param {String|NodeElement|NodeList} target
+   * @return {Boolean}
+   */
+  static hasInstance(target) {
+    const instances = this.instances || []
+    target = getDomElement(target)
+
+    for (let i = 0; i < instances.length; i++) {
+      if (instances[i].getElement() === target) {
+        return true
+      }
+    }
+
+    return false
+  }
+
+  /**
+   * getInstance
+   * @param {String|NodeElement|NodeList} target
+   * @return {Object|null}
+   */
+  static getInstance(target) {
+    const instances = this.instances || []
+    target = getDomElement(target)
+
+    for (let i = 0; i < instances.length; i++) {
+      if (instances[i].getElement() === target) {
+        return instances[i]
+      }
+    }
+
+    return null
+  }
+
+  /**
+   * foreach
+   * @param {String|NodeElement|NodeList|Function} targets
+   * @param {Function} callback
+   * @return {Object} this
+   */
+  static foreach(targets, callback) {
+    const instances = this.instances || []
+
+    if (typeof targets === 'function') {
+      callback = targets
+
+      for (let i = 0; i < instances.length; i++) {
+        callback(instances[i])
+      }
+    } else {
+      const elements = getDomElements(targets)
+
+      for (let i = 0; i < elements.length; i++) {
+        let instance = this.getInstance(elements[i])
+
+        if (instance) {
+          callback(instance)
+        }
+      }
+    }
+
+    return this
+  }
+
+  /**
+   * destroy
+   * @param {String|NodeElement|NodeList|undefined} targets
+   * @return {Object} this
+   */
+  static destroy(targets) {
+    const instances = this.instances || []
+
+    if (targets) {
+      let elements = getDomElements(targets)
+
+      for (let i = 0; i < elements.length; i++) {
+        let instance = this.getInstance(elements[i])
+        if (instance) {
+          instance.destroy()
+        }
+      }
+    } else {
+      while (instances[0]) {
+        instances[0].destroy()
+      }
     }
 
     return this
@@ -135,26 +227,42 @@ class AbstractDomElement {
 // ----
 // utils
 // ----
-function foreach(element, callback) {
-  const el = getDomElements(element)
-  let i
-
-  for (i = 0; i < el.length; i++) {
-    if (callback(el[i]) === false) {
-      break
-    }
-  }
-}
-
 function getDomElements(element) {
   return typeof element === 'string' ? document.querySelectorAll(element) : element.length >= 0 ? element : [element]
 }
 
 function getDomElement(element) {
-  return getDomElements(element)[0]
+  return typeof element === 'string' ? document.querySelector(element) : element.length >= 0 ? element[0] : element
+}
+
+function buildSettings(childClass, options) {
+  const array = [options, childClass.defaults]
+  const abstractDomElementProto = Object.getPrototypeOf(AbstractDomElement)
+  let proto = Object.getPrototypeOf(childClass)
+
+  while (proto && proto !== abstractDomElementProto) {
+    if (proto.defaults) {
+      array.push(proto.defaults)
+    }
+
+    proto = Object.getPrototypeOf(proto.constructor)
+  }
+
+  array.push(AbstractDomElement.defaults, {}, true)
+
+  return extend.apply(null, array.reverse())
 }
 
 // ----
-// export
+// static props
 // ----
+AbstractDomElement.defaults = {
+  autoInit: true,
+  autoRegisterChildren: true,
+  selectors: {
+    // name: 'selector' will create this._name = nodeList if autoRegisterChildren is set to true
+    // buttons: '.button' will create this._buttons = nodeList
+  },
+}
+
 export default AbstractDomElement

--- a/src/js/classes/Animation.js
+++ b/src/js/classes/Animation.js
@@ -5,21 +5,13 @@ import noop from '../utils/noop'
 // ----
 // shared variables
 // ----
-const instances = []
 let scrollObserver
 
 // ----
 // class Animation
 // ----
 class Animation extends AbstractDomElement {
-  constructor(element, options) {
-    const instance = super(element, options)
-
-    // avoid double init :
-    if (!instance.isNewInstance()) {
-      return instance
-    }
-
+  init() {
     const that = this
     const el = this._element
     const s = this._settings
@@ -29,9 +21,6 @@ class Animation extends AbstractDomElement {
 
     this._isVisible = false
     this._callbacksSharedData = callbacksSharedData
-
-    // add to instances
-    instances.push(this)
 
     // init scrollObserver
     if (!scrollObserver) {
@@ -74,18 +63,12 @@ class Animation extends AbstractDomElement {
   destroy() {
     const el = this._element
     const s = this._settings
-    const index = instances.indexOf(this)
     const callbacksSharedData = this._callbacksSharedData
     let scrollInfos
-
-    if (index === -1) {
-      return
-    }
 
     super.destroy()
 
     scrollInfos = scrollObserver.getScrollInfos()
-    instances.splice(index, 1)
 
     if (s.showOnDestroy) {
       s.onShow(el, scrollInfos, callbacksSharedData)
@@ -99,12 +82,6 @@ class Animation extends AbstractDomElement {
     }
 
     this._settings.onDestroy(el, scrollInfos, callbacksSharedData)
-  }
-
-  static destroy() {
-    while (instances.length) {
-      instances[0].destroy()
-    }
   }
 }
 
@@ -121,7 +98,7 @@ Animation.defaults = {
   // end (relative to bottom of the screen), can be a float, a function (element) {} or an array of two values (range) []
   end: 0.75,
   // if true, the instance will be destroyed after the element is visible
-  playOnce: false,
+  playOnce: true,
   // if true, remove the visible class when the element reach the end paramter value
   hideOnReachEnd: false,
   // if true, set the element visible on destroy whatever the current scroll value
@@ -151,7 +128,7 @@ function getValue(element, value) {
 // ----
 // presets
 // ----
-Animation.preset = {
+Animation.presets = {
   '.js-animation .js-animation-opacity': undefined,
   '.js-animation .js-animation-translation': {
     animationClass: 'js-animation-translation',
@@ -201,7 +178,7 @@ Animation.preset = {
 // ----
 // presets
 // ----
-Animation.initFromPreset()
+Animation.init()
 
 // ----
 // export

--- a/src/js/classes/ButtonSeoClick.js
+++ b/src/js/classes/ButtonSeoClick.js
@@ -5,14 +5,7 @@ import openUrlInNewTab from '../utils/openUrlInNewTab'
 // class
 // ----
 class ButtonSeoClick extends AbstractDomElement {
-  constructor(element, options) {
-    const instance = super(element, options)
-
-    // avoid double init :
-    if (!instance.isNewInstance()) {
-      return instance
-    }
-
+  init() {
     this._element.addEventListener('click', onClickButton)
   }
 }

--- a/src/js/classes/Header.js
+++ b/src/js/classes/Header.js
@@ -4,14 +4,7 @@ import each from '../utils/each'
 import { Tween } from 'oneloop.js'
 
 class Header extends AbstractDomElement {
-  constructor(element, options) {
-    const instance = super(element, options)
-
-    // avoid double init :
-    if (!instance.isNewInstance()) {
-      return instance
-    }
-
+  init() {
     const that = this
     const el = this._element
     const toggle = el.getElementsByClassName('header__menu-toggle')[0]

--- a/src/js/classes/ScrollDirection.js
+++ b/src/js/classes/ScrollDirection.js
@@ -2,14 +2,7 @@ import AbstractDomElement from './AbstractDomElement.js'
 import { ScrollObserver } from 'oneloop.js'
 
 class ScrollDirection extends AbstractDomElement {
-  constructor(element, options) {
-    const instance = super(element, options)
-
-    // avoid double init :
-    if (!instance.isNewInstance()) {
-      return instance
-    }
-
+  init() {
     const that = this
 
     this._scrollObserver = new ScrollObserver()


### PR DESCRIPTION
```
Class Exemple extends AbstractDomElement {
	init() {

	}
}

Exemple.defaults = {
	// paramètres par défaut
}

Exemple.presets = {
	'.selector': {...}
}
```

### Modifications :

- Les méthodes initFromPreset et destroyFromPreset ont été supprimées. Elles sont remplacées par la méthode static init() et destroy() sans argument.
- L'extension des paramètres par défaut des class intermédiaires est désormais pris en charge (A extends AbstractDomElement, B extends A).
-  Plus de collision possible si plusieurs class sont initialisées sur un même élément lors de la minification 
- L'instance n'est plus stockée sur le nodeElement
- preset prend désormais un "s": Exemple.presets

#### Méthode static init :
```
Exemple.init() // initialise tous les presets
Exemple.init('.selector') // initialise .selector avec les options de l'objet presets
Exemple.init('.selector', {...}) // initialise .selector avec les options passées en argument 
Exemple.init('.an-other-selector') // initialise .selector avec les options par défaut
Exemple.init('.an-other-selector', {...}) // initialise .an-other-selector avec les options passées en argument 
```

#### Méthode static destroy :
```
Exemple.destroy() // détruit toutes les instances de la class Exemple
Exemple.destroy('.selector') // détruit toutes les instances .selector de la class Exemple
```

#### Méthode abstraite init :
Ajout de la méthode init, appelée par défaut dans le constructeur de AbstractDomElement. Pour désactiver l’appel il est possible d’ajouter dans les settings `autoInit: false`. Cela permet également d'omettre le constructeur (voir la class Exemple).

```
Exemple.defaults = {
	autoInit: false,
}
```

#### Méthode getElement :
Renvoie l'élément sur lequel a été intialisée la class.

#### Méthode registerChildren :
Si le paramètre `selectors` a été renseigné et que le paramètre `autoRegisterChildren` n’a pas été défini a false, les élémentq seront automatiquement ajoutés à l'instance :
```
Exemple.defaults = {
	selectors: {
		buttons: '.card__content .button' // création automatique de  this._buttons = NodeList
	},
}
``` 

Pour désactiver la sélection automatique des éléments, il faut ajouter l’option :
```
Exemple.defaults = {
	autoRegisterChildren: false,
}
``` 

#### Méthode find(selector) :
Raccourci pour `this._element.querySelectorAll(selector)`

