### PR TITLE
fix admin bar mobile not sticky

### DIFF
--- a/src/scss/03-base/_variables-css.scss
+++ b/src/scss/03-base/_variables-css.scss
@@ -70,6 +70,17 @@
      * Global breakpoints
      */
 
+    @include breakpoints(s, max) {
+        /*
+         * Admin bar become not sticky
+         */
+        &:not(.scroll-top) {
+            .admin-bar {
+                --wp-admin-bar-height: 0rem;
+            }
+        }
+    }
+
     @include breakpoints(admin-bar) {
         /*
          * Admin bar

--- a/src/scss/04-utilities/_aria.scss
+++ b/src/scss/04-utilities/_aria.scss
@@ -1,11 +1,11 @@
 [aria-expanded="false"] {
-	.aria-expanded-true-text {
-		display: none !important;
-	}
+    .aria-expanded-true-text {
+        display: none !important;
+    }
 }
 
 [aria-expanded="true"] {
-	.aria-expanded-false-text {
-		display: none !important;
-	}
+    .aria-expanded-false-text {
+        display: none !important;
+    }
 }

--- a/src/scss/04-utilities/_wp-admin-bar.scss
+++ b/src/scss/04-utilities/_wp-admin-bar.scss
@@ -1,0 +1,5 @@
+#wpadminbar {
+    @include breakpoints(sm, max) {
+        overflow: hidden;
+    }
+}

--- a/src/scss/04-utilities/_wp-admin-bar.scss
+++ b/src/scss/04-utilities/_wp-admin-bar.scss
@@ -1,5 +1,5 @@
 #wpadminbar {
     @include breakpoints(sm, max) {
-        overflow: hidden;
+        overflow: scroll;
     }
 }

--- a/src/scss/04-utilities/utilities.scss
+++ b/src/scss/04-utilities/utilities.scss
@@ -1,3 +1,4 @@
+@import "./wp-admin-bar";
 @import "./focus";
 @import "./lazyload";
 @import "./seo";

--- a/src/scss/08-template-parts/_header.scss
+++ b/src/scss/08-template-parts/_header.scss
@@ -205,14 +205,6 @@
         }
     }
 
-    @include breakpoints(s, max) {
-        .scroll-up &__inner,
-        .scroll-down &__inner,
-        .scroll-bottom &__inner {
-            top: 0;
-        }
-    }
-
     @include breakpoints(sm) {
         &__menu {
             #{$el}__logo-link {


### PR DESCRIPTION
Suite aux modifs de Nico #309 

**1. L'admin bar devient non sticky en mobile.**

Au lieu de fixer dans le header, on garde le même principe dans les variables CSS et on passe sa hauteur à 0.

Utile car souvent nous gérons du sticky sur d'autres éléments que le header (par exemple les ancres ou un bandeau d'alerte) donc il faudrait sinon fixer le soucis à chaque fois qu'on a du sticky.

**2. Overflow admin bar mobile qui provoque toujours des décalage horizontaux.**

**3. Et un petit soucis d'indentation sur un fichier qui provoquer des erreurs stylelint**