### PR TITLE
fix acf block width

### DIFF
--- a/src/scss/06-blocks/_gutenberg.scss
+++ b/src/scss/06-blocks/_gutenberg.scss
@@ -43,6 +43,21 @@
         margin-left: auto;
     }
 
+    @include editor-only {
+        > .wp-block[class*="wp-block-acf"] {
+            width: 100%;
+            max-width: none;
+        }
+
+        // The template block must have a ".block" class. Example : <div class="block block--my-custom-block">
+        > :where(.wp-block[class*="wp-block-acf"]) :where(.block) {
+            width: $container-default;
+            max-width: var(--responsive--aligndefault-width);
+            margin-right: auto;
+            margin-left: auto;
+        }
+    }
+
     #{context-selector(".alignwide", "[data-align='wide']")} {
         max-width: var(--responsive--alignwide-width);
     }


### PR DESCRIPTION
Permet de pouvoir retrouver la même largeur du bloc ACF en BO qu'en front dans le cas ou l'alignement est désactivé sur le block. Sinon le block en BO a toujours l'alignement par défaut en BO à cause de ça :

```
.editor-styles-wrapper .is-root-container > :where(*) {
    max-width: calc(100% - 2.125rem);
    max-width: var(--responsive--aligndefault-width);
    margin-right: auto;
    margin-left: auto;
}
```

Utilisé sur infopro par @n-langle  et récurrent sur les projets.

____

**Exemple de la structure du block pour un alignwide :** 

```
<div class="block block--testimonial">
	Content here
</div>
```

```
.block {
    $el: &;

    &--testimonial {
        width: $container-wide;
        max-width: var(--responsive--alignwide-width);
    }
}
```

Le block aura donc la même largeur en front et en BO