### PR TITLE
feat (Svg): replace xlink:href attribute of SVG with href attribute

### DIFF
--- a/inc/Services/Svg.php
+++ b/inc/Services/Svg.php
@@ -55,7 +55,7 @@ class Svg implements Service {
 		$classes   = array_merge( $classes, $additionnal_classes );
 		$classes   = array_map( 'sanitize_html_class', $classes );
 
-		return sprintf( '<svg class="%s" aria-hidden="true" focusable="false"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="%s#%s"></use></svg>', implode( ' ', $classes ), \get_theme_file_uri( sprintf( '/dist/icons/%s.svg', $sprite_name ) ), $icon_slug ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		return sprintf( '<svg class="%s" aria-hidden="true" focusable="false"><use href="%s#%s"></use></svg>', implode( ' ', $classes ), \get_theme_file_uri( sprintf( '/dist/icons/%s.svg', $sprite_name ) ), $icon_slug ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**


### PR DESCRIPTION
Remplace l'attribut `xlink:href` de l'élément `<use>` avec l'attribut `href`.

L'attribut `xlink:href` est déprécié. 

> Deprecated: This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards, may be in the process of being dropped, or may only be kept for compatibility purposes. Avoid using it, and update existing code if possible; see the [compatibility table](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href#browser_compatibility) at the bottom of this page to guide your decision. Be aware that this feature may cease to work at any time.

Voir https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href

## Avant
```html
<svg class="icon icon-search" aria-hidden="true" focusable="false">
  <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://secours-populaire-uas.lndo.site/app/themes/secours-populaire-uas/dist/icons/sprite.svg#icon-search"></use>
</svg>
```
## Après
```html
<svg class="icon icon-search" aria-hidden="true" focusable="false">
  <use href="https://secours-populaire-uas.lndo.site/app/themes/secours-populaire-uas/dist/icons/sprite.svg#icon-search"></use>
</svg>
```