### PR TITLE
wp block group - add full width mobile class

### DIFF
--- a/src/scss/06-blocks/core/_group.scss
+++ b/src/scss/06-blocks/core/_group.scss
@@ -13,7 +13,7 @@
     }
 
     @include breakpoints(sm, max) {
-        &--full-with-mobile {
+        &--full-mobile {
             max-width: 100% !important;
         }
     }

--- a/src/scss/06-blocks/core/_group.scss
+++ b/src/scss/06-blocks/core/_group.scss
@@ -11,6 +11,12 @@
             }
         }
     }
+
+    @include breakpoints(sm, max) {
+        &--full-with-mobile {
+            max-width: 100% !important;
+        }
+    }
 }
 
 @include editor-only {


### PR DESCRIPTION
Au même titre que la class `wp-block-group--no-inner-margin` qui va reset les marges internes quand on l'utilise dans nos patterns.

Ajout de la class `wp-block-group--full-width-mobile` qui permettra d'avoir le groupe en full-width sur mobile.
Souvent le cas dans les pattern quand on a un fond de couleur ou une image de fond.