### PR TITLE
replace input submit to button submit gravity form

### DIFF
--- a/src/js/classes/GravityForms.js
+++ b/src/js/classes/GravityForms.js
@@ -1,0 +1,62 @@
+import AbstractDomElement from './AbstractDomElement'
+import $ from 'jquery'
+
+class GravityForms extends AbstractDomElement {
+  constructor(element, options) {
+    const instance = super(element, options)
+
+    // avoid double init :
+    if (!instance.isNewInstance()) {
+      return instance
+    }
+
+    this.init()
+  }
+
+  /**
+   * Initialization
+   */
+  init() {
+    this.createSubmitButton()
+
+    // For ajax gform
+    $(document).on('gform_post_render', this.createSubmitButton.bind(this))
+  }
+
+  /**
+   * Replace input[type="submit"] with button[type="submit"]
+   */
+  createSubmitButton() {
+    const el = this._element
+    const { inputSubmit } = this._settings
+    const $input = el.querySelector(inputSubmit)
+    const $button = document.createElement('button')
+
+    if ($input) {
+      $input.getAttributeNames().map((attr) => {
+        if (attr === 'value') {
+          $button.innerHTML = `${$input.getAttribute(attr)}`
+        } else {
+          $button.setAttribute(attr, $input.getAttribute(attr))
+        }
+      })
+
+      $input.parentNode.prepend($button)
+      $input.parentNode.removeChild($input)
+    }
+  }
+}
+
+GravityForms.defaults = {
+  inputSubmit: 'input[type="submit"]',
+}
+
+// ----
+// init
+// ----
+GravityForms.init('.gform_wrapper')
+
+// ----
+// export
+// ----
+export default GravityForms

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -6,6 +6,7 @@ import './classes/ScrollDirection'
 import './classes/ButtonSeoClick'
 import './classes/Header'
 import './classes/Animation'
+import './classes/GravityForms'
 
 /**
  * LazySizes configuration


### PR DESCRIPTION
Pour remplacer l'input submit par un button de type submit dans gravity form.

Utilisé sur plusieurs projets, et initié par @firestar300 sur InforPro. Car souvent nous avons des before ou after pour gérer les fonds sur les boutons.

Compatible également avec le formulaire en Ajax.

A voir si c'est utile, ou bien à commenter et à utiliser au besoin.

**Attention, à refactorer le fichier avant de merger la PR de @n-langle #319 suite au refactor de la class AbstractDomElement**