### PR TITLE
ACF table not impact

### DIFF
--- a/src/scss/02-tools/_m-not-acf.scss
+++ b/src/scss/02-tools/_m-not-acf.scss
@@ -1,0 +1,6 @@
+// Not apply style to ACF fields
+@mixin not-acf() {
+    #{context-selector(":where(body)", ":where(*:not([class*="acf-"])) >")} {
+        @content;
+    }
+}

--- a/src/scss/02-tools/tools.scss
+++ b/src/scss/02-tools/tools.scss
@@ -37,3 +37,4 @@
 @import "./m-block-vertical-spacing";
 @import "./m-background-static";
 @import "./m-invisible-scrollbar";
+@import "./m-not-acf";

--- a/src/scss/03-base/_forms.scss
+++ b/src/scss/03-base/_forms.scss
@@ -11,7 +11,7 @@ $text-inputs-list: 'input[type="color"]', 'input[type="date"]',
 $all-text-inputs: assign-inputs($text-inputs-list);
 
 // Not apply style to ACF fields
-#{context-selector(":where(body)", ":where(*:not([class*="acf-"])) >")} {
+@include not-acf {
     // Textarea
     textarea {
         resize: vertical;

--- a/src/scss/06-blocks/core/_table.scss
+++ b/src/scss/06-blocks/core/_table.scss
@@ -1,6 +1,16 @@
-table,
-.wp-block-table {
+%table {
     width: 100%;
     min-width: 240px;
     border-collapse: collapse;
+}
+
+.wp-block-table {
+    @extend %table;
+}
+
+// Not apply style to ACF fields
+@include not-acf {
+    table {
+        @extend %table;
+    }
 }


### PR DESCRIPTION
Pour éviter les conflits avec les table ACF.

Création d'un mixin sur la base de ce qu'on avait fait pour les éléments de formulaire pour éviter de répéter le sélecteur à chaque fois.