### PR TITLE
fix (webpack): don't include wp-polyfill dependencies automatically

### DIFF
--- a/config/plugins.js
+++ b/config/plugins.js
@@ -31,7 +31,7 @@ module.exports = {
       new WebpackBar({
         color: '#ffe600',
       }),
-      new DependencyExtractionWebpackPlugin({ injectPolyfill: true }),
+      new DependencyExtractionWebpackPlugin(),
     ]
 
     if (mode === 'production') {


### PR DESCRIPTION
Follow up to #278, remove option `injectPolyfill` in webpack plugin dependency-extraction-webpack-plugin. This will reduce the number of scripts loaded on the page and save on resources. Scripts will need to explicitely declare the dependencies if they want to include it. The dependency will also be included if one of the script dependecy requires it.