### PR TITLE
Fix/complianz checkbox

### DIFF
--- a/src/scss/03-base/_forms.scss
+++ b/src/scss/03-base/_forms.scss
@@ -69,7 +69,7 @@ $all-text-inputs: assign-inputs($text-inputs-list);
         For complianz plugin
         --------------------
 
-        *:not(.cmplz-banner-checkbox) > & {
+        span:not(.cmplz-banner-checkbox) > & {
             @include checkbox-custom;
 
             &:checked {
@@ -87,7 +87,7 @@ $all-text-inputs: assign-inputs($text-inputs-list);
         For complianz plugin
         --------------------
 
-        *:not(.cmplz-banner-checkbox) > & {
+        span:not(.cmplz-banner-checkbox) > & {
             @include radio-custom(true);
         }
         */

--- a/src/scss/03-base/_forms.scss
+++ b/src/scss/03-base/_forms.scss
@@ -63,35 +63,29 @@ $all-text-inputs: assign-inputs($text-inputs-list);
         &:checked {
             @include checkbox-custom-checked;
         }
+    }
 
-        /*
-        --------------------
-        For complianz plugin
-        --------------------
+    input[type="radio"] {
+        @include radio-custom(true);
+    }
 
-        span:not(.cmplz-banner-checkbox) > & {
+    /*
+    // For complianz plugin
+    *:not(.cmplz-banner-checkbox) > {
+        input[type="checkbox"],
+        input[type="radio"] {
             @include checkbox-custom;
 
             &:checked {
                 @include checkbox-custom-checked;
             }
         }
-        */
-    }
 
-    input[type="radio"] {
-        @include radio-custom(true);
-
-        /*
-        --------------------
-        For complianz plugin
-        --------------------
-
-        span:not(.cmplz-banner-checkbox) > & {
+        input[type="radio"] {
             @include radio-custom(true);
         }
-        */
     }
+    */
 
     input[type="submit"] {
         @extend %btn-block;


### PR DESCRIPTION
entre temps les éléments des forms ont été passé dans le mixin "not-acf" qui fais un :where(body) donc la structure n'allait plus.