### PR TITLE
feat (skip-links): set top value with --wp-admin--admin-bar--height

### DIFF
--- a/src/scss/03-base/_variables-css.scss
+++ b/src/scss/03-base/_variables-css.scss
@@ -41,10 +41,10 @@
     /*
      * Admin bar
      */
-    --wp-admin-bar-height: 0rem;
+    --wp-admin-bar-height: var(--wp-admin--admin-bar--height, 0rem);
 
     .admin-bar {
-        --wp-admin-bar-height: 46px;
+        --wp-admin-bar-height: var(--wp-admin--admin-bar--height, 46px);
     }
 
     /*
@@ -76,7 +76,7 @@
          */
         &:not(.scroll-top) {
             .admin-bar {
-                --wp-admin-bar-height: 0rem;
+                --wp-admin-bar-height: var(--wp-admin--admin-bar--height, 0rem);
             }
         }
     }
@@ -86,7 +86,7 @@
          * Admin bar
          */
         .admin-bar {
-            --wp-admin-bar-height: 32px;
+            --wp-admin-bar-height: var(--wp-admin--admin-bar--height, 32px);
         }
     }
 

--- a/src/scss/03-base/_variables-css.scss
+++ b/src/scss/03-base/_variables-css.scss
@@ -43,10 +43,6 @@
      */
     --wp-admin-bar-height: var(--wp-admin--admin-bar--height, 0rem);
 
-    .admin-bar {
-        --wp-admin-bar-height: var(--wp-admin--admin-bar--height, 46px);
-    }
-
     /*
      * Alignments breakpoints
      */
@@ -76,17 +72,8 @@
          */
         &:not(.scroll-top) {
             .admin-bar {
-                --wp-admin-bar-height: var(--wp-admin--admin-bar--height, 0rem);
+                --wp-admin-bar-height: 0px;
             }
-        }
-    }
-
-    @include breakpoints(admin-bar) {
-        /*
-         * Admin bar
-         */
-        .admin-bar {
-            --wp-admin-bar-height: var(--wp-admin--admin-bar--height, 32px);
         }
     }
 

--- a/src/scss/05-components/_skip-links.scss
+++ b/src/scss/05-components/_skip-links.scss
@@ -1,6 +1,6 @@
 .skip-links {
     position: absolute;
-    top: 0;
+    top: var(--wp-admin-bar-height);
     left: 0;
     z-index: 10;
     display: flex;


### PR DESCRIPTION
Pour information, la variable `--wp-admin--admin-bar--height` est fournie nativement par WordPress depuis `admin.css`.