### PR TITLE
fix columns

### DIFF
--- a/src/scss/06-blocks/core/_columns.scss
+++ b/src/scss/06-blocks/core/_columns.scss
@@ -1,22 +1,23 @@
 .wp-block-columns {
     gap: get-gutter-width() !important;
 
+    .wp-block-column {
+        &.has-background {
+            padding: var(--spacing--block-1);
+        }
+    }
+
     &:not(.is-not-stacked-on-mobile) {
         .wp-block-column {
             margin-left: 0 !important;
-
-            &:not(:only-child) {
-                flex-basis: 100% !important;
-            }
         }
 
-        @include breakpoints(sm, mdl) {
+        @include breakpoints(md, max) {
             flex-wrap: wrap !important;
 
             .wp-block-column {
                 &:not(:only-child) {
-                    flex-basis: calc(50% - #{get-gutter-width() * .5}) !important;
-                    flex-grow: 0 !important;
+                    flex-basis: 100% !important;
                 }
             }
         }

--- a/src/scss/06-blocks/core/_columns.scss
+++ b/src/scss/06-blocks/core/_columns.scss
@@ -1,4 +1,5 @@
 .wp-block-columns {
+    @include block-vertical-spacing();
     gap: get-gutter-width() !important;
 
     .wp-block-column {


### PR DESCRIPTION
Fix sur les colonnes.

1. Avant c'était limité à du 50/50 sur toutes les variantes 
2. Ajout padding sur les colonnes qui ont un fond de couleur
3. Ajout de l'espacement vertical entre les blocs (cet espace est automatiquement annulé si l'élément est imbriqué)

<img width="1357" alt="Capture d’écran 2023-09-11 à 14 10 13" src="https://github.com/BeAPI/beapi-frontend-framework/assets/7815271/3826bf92-3528-4bee-9174-77ee3a70b8eb">
