### PR TITLE
input search clear

### DIFF
--- a/src/scss/03-base/_forms.scss
+++ b/src/scss/03-base/_forms.scss
@@ -94,4 +94,17 @@ $all-text-inputs: assign-inputs($text-inputs-list);
     input[type="reset"] {
         @extend %btn-block-outline;
     }
+
+    input[type="search"] {
+        &::-webkit-search-cancel-button {
+            width: 16px;
+            height: 16px;
+            cursor: pointer;
+            background-image: get-svg-url("close", $color-dark);
+            background-size: contain;
+            -webkit-appearance: none;
+            -moz-appearance: none;
+            appearance: none;
+        }
+    }
 }


### PR DESCRIPTION
Pseudo élément pour clear la recherche sur chrome.
On reprend l'icône close du thème pour garder une cohérence et on lui fixe une couleur. Sinon il est bleu par défaut.