### PR TITLE
feat (Assets): add theme data as inline script

### DIFF
--- a/inc/Services/Assets.php
+++ b/inc/Services/Assets.php
@@ -81,6 +81,15 @@ class Assets implements Service {
 	public function enqueue_scripts(): void {
 		// JS
 		$this->assets_tools->enqueue_script( 'scripts' );
+
+		wp_add_inline_script(
+			'scripts',
+			'const THEME_DATA = ' . wp_json_encode(
+				[
+					'themeUri' => get_template_directory_uri(),
+				]
+			),
+		);
 	}
 
 	/**

--- a/inc/Services/Assets.php
+++ b/inc/Services/Assets.php
@@ -71,6 +71,15 @@ class Assets implements Service {
 			true
 		);
 
+		wp_add_inline_script(
+			'scripts',
+			'const THEME_DATA = ' . wp_json_encode(
+				[
+					'themeUri' => get_template_directory_uri(),
+				]
+			),
+		);
+
 		// CSS
 		wp_register_style( 'theme-style', get_stylesheet_uri(), [], $version );
 	}
@@ -81,15 +90,6 @@ class Assets implements Service {
 	public function enqueue_scripts(): void {
 		// JS
 		$this->assets_tools->enqueue_script( 'scripts' );
-
-		wp_add_inline_script(
-			'scripts',
-			'const THEME_DATA = ' . wp_json_encode(
-				[
-					'themeUri' => get_template_directory_uri(),
-				]
-			),
-		);
 	}
 
 	/**


### PR DESCRIPTION
Permet de poser dans le DOM une variable JS d'objet comprenant de base l'url vers le thème courant. Pratique parfois pour accéder à des fichiers depuis le JS du thème.