### PR TITLE
feat (lazysizes): disable lazyloading for media print

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,6 +1,7 @@
 import lazySizes from 'lazysizes'
 import 'lazysizes/plugins/native-loading/ls.native-loading'
 import 'lazysizes/plugins/object-fit/ls.object-fit'
+import 'lazysizes/plugins/print/ls.print'
 import 'what-input'
 import './classes/ScrollDirection'
 import './classes/ButtonSeoClick'


### PR DESCRIPTION
Désactive le lazyloading pour les pages d'impression. Permet donc d'avoir les images quand on imprime une page.