### PR TITLE
fix svg url mixin for use css mask

### DIFF
--- a/src/scss/02-tools/_f-get-svg-url.scss
+++ b/src/scss/02-tools/_f-get-svg-url.scss
@@ -25,5 +25,9 @@
         $style: " style='" + $style + "'";
     }
 
-    @return url("data:image/svg+xml;charset=utf8, %3Csvg xmlns='http://www.w3.org/2000/svg' fill='rgba(#{red($fill), green($fill), blue($fill), $opacity})'" + $style + " viewBox='" + nth(map.get($svgs, $name), 1) + "'%3E%" + nth(map.get($svgs, $name), 2) + "%3C/svg%3E");
+    @if ($fill != "") {
+        $fill: " fill='rgba(#{red($fill), green($fill), blue($fill), $opacity})'";
+    }
+
+    @return url("data:image/svg+xml;charset=utf8, %3Csvg xmlns='http://www.w3.org/2000/svg'" + $fill + $style + " viewBox='" + nth(map.get($svgs, $name), 1) + "'%3E%" + nth(map.get($svgs, $name), 2) + "%3C/svg%3E");  /* stylelint-disable-line */
 }


### PR DESCRIPTION
Suite au commentaire de Nico : https://beapi.slack.com/archives/C07N6N477/p1700749120843589?thread_ts=1700748520.245959&cid=C07N6N477

Rend optionnel la couleur pour pouvoir utiliser les mask CSS

```
.my-icon {
    width; 20px;
    height: 20px;
    background-color: #ff0000;
    -webkit-mask-image: get-svg-url("home", "");
    mask-image: get-svg-url("home", "");
}
```