### PR TITLE
fix eslintrc - (conflict on vip projects with the editorconfig file)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,7 +25,8 @@
                 "trailingComma": "es5",
                 "singleQuote": true,
                 "printWidth": 120,
-                "semi": false
+                "semi": false,
+                "useTabs": false
             }
         ]
     },


### PR DESCRIPTION
Pour éviter les conflits avec le fichier `.editorconfig` à la racine des projets VIP. Car sinon à la compilation il demande de tout convertir en tabs.

Le fichier `.editorconfig` des projets VIP est configuré comme cela : 

```
root = true

[*]
charset = utf-8
end_of_line = lf
insert_final_newline = true
trim_trailing_whitespace = true
indent_style = tab

[*.yml]
indent_style = space
indent_size = 2

[*.md]
trim_trailing_whitespace = false

[*.txt]
end_of_line = crlf
```