### PR TITLE
fix skip links visibility for Safari

### DIFF
--- a/src/scss/05-components/_skip-links.scss
+++ b/src/scss/05-components/_skip-links.scss
@@ -7,7 +7,7 @@
     padding: .5rem 1rem;
     color: $color-text;
     background-color: $color-primary;
-    transition: transform .3s ease-in-out;
+    transition: transform .3s ease-in-out, opacity .3s ease-in-out;
     transform: translate3d(0, -100%, 0);
     opacity: 0;
 

--- a/src/scss/05-components/_skip-links.scss
+++ b/src/scss/05-components/_skip-links.scss
@@ -9,9 +9,11 @@
     background-color: $color-primary;
     transition: transform .3s ease-in-out;
     transform: translate3d(0, -100%, 0);
+    opacity: 0;
 
     &:focus-within {
         transform: translate3d(0, 0, 0);
+        opacity: 1;
     }
 
     li:not(:last-of-type) {


### PR DESCRIPTION
There is a bug in Safari with skip links : they are visible when scrolling top.
This PR fix it with zero opacity on container until links are focused.

<img width="1322" alt="clipboard-202402141057-dajjv" src="https://github.com/BeAPI/beapi-frontend-framework/assets/7976501/2b6c3ebc-352e-41d2-9b61-cede8a72cd74">
