### PR TITLE
fix admin bar unit

### DIFF
--- a/src/scss/03-base/_variables-css.scss
+++ b/src/scss/03-base/_variables-css.scss
@@ -87,7 +87,7 @@
          */
         &:not(.scroll-top) {
             .admin-bar {
-                --wp-admin-bar-height: 0px;
+                --wp-admin-bar-height: 0rem;
             }
         }
     }


### PR DESCRIPTION
soucis de calcul avec la valeur px avec les calc

exemple : `top: calc(-1 * var(--height-header) + var(--wp-admin-bar-height));`ne fonctionnait pas comme voulu