### PR TITLE
fix form error on chromium

### DIFF
--- a/src/scss/03-base/_reset.scss
+++ b/src/scss/03-base/_reset.scss
@@ -57,6 +57,10 @@ html {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     text-rendering: auto;
+
+    &:has(main form) {
+        scroll-behavior: auto; // Prevent not display error on required field on Chromium : https://issues.chromium.org/issues/40196176 / https://stackoverflow.com/questions/69015407/html5-form-validation-message-doesnt-show-when-scroll-behaviour-is-set-to-smoo
+    }
 }
 
 /**


### PR DESCRIPTION
Permet de fixer le bug présent dans chrome non résolu à ce jour.

Le soucis se produit sur des petits écrans où on a besoin de scroller pour appuyer sur le bouton submit, et quand ça rescroll en haut ça n'affiche pas le message natif sur les champs en required qui n'étaient plus visibles à l'écran au moment du clic sur le submit, cela en effet à cause de la propriété scroll-behavior à smooth.

https://stackoverflow.com/questions/69015407/html5-form-validation-message-doesnt-show-when-scroll-behaviour-is-set-to-smoo

https://issues.chromium.org/issues/40196176