### PR TITLE
fix pattern file header

### DIFF
--- a/patterns/media-text.php
+++ b/patterns/media-text.php
@@ -2,7 +2,8 @@
 /**
  * Title: Media Text
  * Slug: beapi-frontend-framework/media-text
- * categories: common
+ * Categories: common
+ * Viewport Width: 1304
  */
 ?>
 <!-- wp:media-text {"align":"","mediaType":"image"} -->


### PR DESCRIPTION
Ajout de Viewport width, car on a souvent le soucis sur les preview de pattern dans la colonne de gauche on a toujours une vue responsive car les breakpoint sont pris en compte.

Avec ça on force l'iframe de la preview à s'afficher à la bonne largeur (donc largeur du container desktop par exemple)

`Viewport Width: The width of the <iframe> viewport when previewing the pattern (in pixels).`

https://developer.wordpress.org/themes/patterns/registering-patterns/