### PR TITLE
fix nolazyload tpl

### DIFF
--- a/assets/conf-img/tpl/square-nolazyload.tpl
+++ b/assets/conf-img/tpl/square-nolazyload.tpl
@@ -1,0 +1,2 @@
+<source srcset="%%img-100-100%%, %%img-200-200%% 2x" media="(max-width: 768px)" />
+<source srcset="%%img-200-200%%, %%img-400-400%% 2x" />

--- a/config/WebpackImageSizesPlugin.js
+++ b/config/WebpackImageSizesPlugin.js
@@ -68,7 +68,12 @@ class WebpackImageSizesPlugin {
      */
     function getTemplateFileNames() {
       return fs.readdirSync(that._tplFolder).filter((tpl) => {
-        if (tpl !== 'default-picture.tpl' && tpl !== 'default-picture-caption.tpl') {
+        if (
+          tpl !== 'default-picture.tpl' &&
+          tpl !== 'default-picture-caption.tpl' &&
+          tpl !== 'default-picture-nolazyload.tpl' &&
+          tpl !== 'default-picture-nolazyload-caption.tpl'
+        ) {
           return tpl
         }
       })


### PR DESCRIPTION
Suite à cette PR : https://github.com/BeAPI/beapi-frontend-framework/pull/422/files

Il manquait l'ajout des fichiers de templates dans la condition pour que ça fonctionne bien

Ajout aussi d'un exemple de tpl pour le non lazyload. car ils ne s'écrivent pas pareil.

On avait uniquement un exemple pour le lazyload et pas pour l'autre

Lazyload : 
```
<source data-srcset="%%img-100-100%%, %%img-200-200%% 2x" media="(max-width: 768px)" %%srcset%% />
<source data-srcset="%%img-200-200%%, %%img-400-400%% 2x" %%srcset%% />
```

Non lazyload (fetchpriority hight) : 

```
<source srcset="%%img-100-100%%, %%img-200-200%% 2x" media="(max-width: 768px)" />
<source srcset="%%img-200-200%%, %%img-400-400%% 2x" />
```