### PR TITLE
fix editor base style

### DIFF
--- a/src/scss/03-base/_body.scss
+++ b/src/scss/03-base/_body.scss
@@ -19,6 +19,17 @@ html {
     text-rendering: auto;
 }
 
+/**
+  * Relax the definition a bit, to allow components to override it manually.
+  */
+* {
+    &,
+    &::before,
+    &::after {
+        box-sizing: inherit;
+    }
+}
+
 body {
     font-family: $font-family-primary;
     font-size: $font-size-base;

--- a/src/scss/editor.scss
+++ b/src/scss/editor.scss
@@ -21,6 +21,7 @@ $entry-file-name: "editor";
 
 @import "./03-base/fonts";
 @import "./03-base/variables-css";
+@import "./03-base/body";
 @import "./03-base/svg-icons";
 @import "./03-base/links";
 @import "./03-base/text";


### PR DESCRIPTION
Suite à la PR de @firestar300 : https://github.com/BeAPI/beapi-frontend-framework/pull/414

Il n'y avait plus le style de base dans l'éditeur car le fichier reset a été enlévé, mais pas remplacé par le nouveau fichier "body"

<img width="437" alt="Capture d’écran 2024-12-16 à 13 05 25" src="https://github.com/user-attachments/assets/daf525c3-7c89-4d74-8fe8-90bb5fcc4fbc" />
