### PR TITLE
columns : add variables for row and column gap

### DIFF
--- a/src/scss/06-blocks/core/_columns.scss
+++ b/src/scss/06-blocks/core/_columns.scss
@@ -1,5 +1,12 @@
 .wp-block-columns {
+    --wp-block-columns-row-gap: var(--spacing--block-2);
+    --wp-block-columns-column-gap: #{get_gutter-width()};
+
     @include block-vertical-spacing();
+
+    row-gap: var(--wp-block-columns-row-gap);
+    column-gap: var(--wp-block-columns-column-gap) !important;
+    justify-content: space-between;
 
     .wp-block-column {
         &.has-background {
@@ -18,6 +25,10 @@
             .wp-block-column {
                 &:not(:only-child) {
                     flex-basis: 100% !important;
+                }
+
+                &:empty {
+                    display: none;
                 }
             }
         }


### PR DESCRIPTION
Ajout de variables pour les gap (row et column) du bloc colonne

Pour avoir la main pour changer facilement les gap dans les pattern par exemple.

Le gap par défaut correspond au gutter définit dans notre grille