### PR TITLE
remove acf rules for gutenberg editor

### DIFF
--- a/src/scss/06-blocks/_gutenberg.scss
+++ b/src/scss/06-blocks/_gutenberg.scss
@@ -59,20 +59,13 @@
     }
 
     @include editor-only {
-        > .wp-block[class*="wp-block-acf"],
         > .wp-block[class*="wp-block-beapi-manual-block"],
         > .wp-block[class*="wp-block-beapi-dynamic-block"] {
             width: 100%;
             max-width: none;
         }
 
-        > .wp-block[class*="wp-block-acf"].is-selected {
-            width: #{$container-wide};
-            max-width: var(--responsive--alignwide-width);
-        }
-
         // The template block must have a ".block" class. Example : <div class="block block--my-custom-block">
-        > :where(.wp-block[class*="wp-block-acf"]) :where(.block),
         > :where(.wp-block[class*="wp-block-beapi-manual-block"]) :where(.block),
         > :where(.wp-block[class*="wp-block-beapi-dynamic-block"]) :where(.block) {
             width: $container-default;


### PR DESCRIPTION
Plus utile avec les derniers versions d'ACF.

Les class d'alignements fonctionnent maintenant bien en BO.

Déjà testé sur 2 projets.