### PR TITLE
Fix text icon external for target blank

### DIFF
--- a/src/scss/02-tools/_m-text-icon.scss
+++ b/src/scss/02-tools/_m-text-icon.scss
@@ -33,7 +33,7 @@
 }
 
 @mixin text-external-icon($icon: "external", $position: after, $color: currentColor, $size: 12px, $gap: 8px) {
-    @include text-icon($icon);
+    @include text-icon($icon, $position, $color, $size);
     display: inline;
 
     &::#{$position} {

--- a/src/scss/02-tools/_m-text-icon.scss
+++ b/src/scss/02-tools/_m-text-icon.scss
@@ -13,10 +13,10 @@
  *
  */
 
-@mixin text-icon($icon: "arrow", $position: after, $color: currentColor, $size: 12px) {
+@mixin text-icon($icon: "arrow", $position: after, $color: currentColor, $size: 12px, $gap: 8px) {
     position: relative;
     display: inline-flex;
-    gap: 8px;
+    gap: $gap;
     align-items: center;
 
     &::#{$position} {
@@ -29,5 +29,15 @@
         mask-position: center;
         mask-repeat: no-repeat;
         transition: background-color .5s $ease-out-expo;
+    }
+}
+
+@mixin text-external-icon($icon: "external", $position: after, $color: currentColor, $size: 12px, $gap: 8px) {
+    @include text-icon($icon);
+    display: inline;
+
+    &::#{$position} {
+        display: inline-block;
+        margin-inline-start: $gap;
     }
 }

--- a/src/scss/03-base/_links.scss
+++ b/src/scss/03-base/_links.scss
@@ -4,7 +4,7 @@ a {
     cursor: pointer;
 
     &[target="_blank"] {
-        @include text-icon("external");
+        @include text-external-icon;
     }
 
     @include hover {
@@ -13,5 +13,5 @@ a {
 }
 
 .link-external {
-    @include text-icon("external");
+    @include text-external-icon;
 }


### PR DESCRIPTION
Fix de l'icône external dans le cas d'un target blank, pour éviter la gestion en flex, mais plutôt qu'il se positionne toujours après le texte si il est sur plusieurs lignes.

<img width="166" alt="Capture d’écran 2025-01-13 à 14 40 02" src="https://github.com/user-attachments/assets/27397bcf-ead6-43bf-a44f-70c4f27b5099" />
<img width="275" alt="Capture d’écran 2025-01-13 à 14 40 14" src="https://github.com/user-attachments/assets/fc78335a-9741-4025-979b-ac2186da14c8" />
