### PR TITLE
fix (theme): remove admin-bar css var

### DIFF
--- a/src/scss/03-base/_variables-css.scss
+++ b/src/scss/03-base/_variables-css.scss
@@ -96,10 +96,6 @@
      */
     --wp-admin-bar-height: var(--wp-admin--admin-bar--height, 0rem);
 
-    &:not(.admin-bar) {
-        --wp-admin-bar-height: 0rem; // for wp admin bar hider extension
-    }
-
     /*
      * A11y reduced motion
      */


### PR DESCRIPTION
Les variables sont définies dans le context :root (balise html), la class .admin-bar est ajoutée sur la balise body