### PR TITLE
fix skip links for screen reader

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -1,5 +1,5 @@
 		</main>
-		<footer id="footer" class="footer" aria-label="<?php esc_attr_e( 'Footer', 'beapi-frontend-framework' ); ?>">
+		<footer id="footer" tabindex="-1" class="footer" aria-label="<?php esc_attr_e( 'Footer', 'beapi-frontend-framework' ); ?>">
 
 		</footer>
 		<?php wp_footer(); ?>

--- a/header.php
+++ b/header.php
@@ -52,7 +52,7 @@ use BEA\Theme\Framework\Helpers\Custom_Menu_Walker;
 						<span class="sr-only aria-expanded-true-text"><?php esc_html_e( 'Close the menu', 'beapi-frontend-framework' ); ?></span>
 					</button>
 
-					<nav id="menu" class="header__menu" aria-label="<?php esc_attr_e( 'Main navigation', 'beapi-frontend-framework' ); ?>">
+					<nav id="menu" tabindex="-1" class="header__menu" aria-label="<?php esc_attr_e( 'Main navigation', 'beapi-frontend-framework' ); ?>">
 						<div>
 							<?php
 							wp_nav_menu(


### PR DESCRIPTION
Ajout d'un tabindex="-1" sur les éléments liés aux liens d'évitements.
Il était uniquement présent sur le contenu principal.

Sans cela, le lecteur d'écran reste sur le lien d'évitement et n'annonce pas le aria-label de la section concernée.