### PR TITLE
Remplacement de l'attribut `crop` par `data-crop` pour des raisons de normes W3C.

### DIFF
--- a/config/WebpackImageSizesPlugin.js
+++ b/config/WebpackImageSizesPlugin.js
@@ -47,7 +47,7 @@ class WebpackImageSizesPlugin {
     const that = this
     const regex = {
       srcset: /srcset="(.[^"]*)"/gm,
-      crop: /crop="(.[^"]*)"/gm,
+      crop: /data-crop="(.[^"]*)"/gm,
       img: /img-\d*-\d*/gm,
     }
 
@@ -164,7 +164,7 @@ class WebpackImageSizesPlugin {
         srcsetArr.forEach((src) => {
           const dimensions = src.match(regex.img)
           const retina = isRetina(src)
-          const crop = !(cropArr && cropArr[0] === 'crop="false"')
+          const crop = !(cropArr && cropArr[0] === 'data-crop="false"')
 
           dimensions.forEach((size, index) => {
             const splitSize = size.split('-')


### PR DESCRIPTION
## Problème

Le validateur W3C remonte cette erreur :
> Attribute `crop` not allowed on element `source` at this point.

## Solution

La solution est d'utiliser le préfixe `data-` sur l'attribut pour que l'erreur ne remonte plus.

## Description

Remplacement de l'attribut `crop` par `data-crop` dans le plugin `config/WebpackImageSizesPlugin.js`. Cela n'aura pas de conséquence sur ARI car la clé sera toujours `crop` dans les JSON.