### PR TITLE
feat (webpack-image-sizes-plugin): adds option to silence console output

### DIFF
--- a/config/plugins.js
+++ b/config/plugins.js
@@ -42,6 +42,7 @@ module.exports = {
         defaultImageSource: 'src/img/static/default.jpg', // Source image for generation
         defaultImagesOutputDir: 'dist/images', // Default images output directory
         defaultImageFormat: 'jpg', // Generated image format (jpg, png, webp, avif)
+        silence: true, // Suppress console output
       }),
     ]
 


### PR DESCRIPTION
Allows users to suppress console output from the plugin.

This adds a `silence` option to the plugin configuration, which, when set to `true`, will prevent most console logs from being printed. This can be useful in environments where excessive logging is undesirable.