### PR TITLE
webpack image sizes plugin

### DIFF
--- a/config/webpack-image-sizes-plugin.js
+++ b/config/webpack-image-sizes-plugin.js
@@ -72,7 +72,7 @@ class WebpackImageSizesPlugin {
    * @memberof WebpackImageSizesPlugin
    */
   apply(compiler) {
-    const context = compiler.context
+    const { context } = compiler
     const confImgPath = path.resolve(context, this.options.confImgPath)
     const sizesPath = path.join(confImgPath, this.options.sizesSubdir)
     const tplPath = path.join(confImgPath, this.options.tplSubdir)

--- a/config/webpack-image-sizes-plugin.js
+++ b/config/webpack-image-sizes-plugin.js
@@ -144,12 +144,12 @@ class WebpackImageSizesPlugin {
     compiler.hooks.emit.tapAsync('WebpackImageSizesPlugin', runGeneration)
 
     // Hook for rebuilds in watch mode
-    compiler.hooks.watchRun.tapAsync('WebpackImageSizesPlugin', (compilation, callback) => {
+    compiler.hooks.watchRun.tapAsync('WebpackImageSizesPlugin', (compiler, callback) => {
       this.log('log', '👀 Watch mode: checking for conf-img changes...')
-      runGeneration(compilation, callback)
+      runGeneration(compiler, callback)
     })
 
-    // Add directories to watch
+    // Add directories to wat
     compiler.hooks.compilation.tap('WebpackImageSizesPlugin', (compilation) => {
       // Watch configuration directories
       if (fs.existsSync(sizesPath)) {

--- a/config/webpack-image-sizes-plugin.js
+++ b/config/webpack-image-sizes-plugin.js
@@ -84,7 +84,6 @@ class WebpackImageSizesPlugin {
         // Assumes that no modified files means the start of the build (yarn start || yarn build)
         if (WebpackImageSizesPlugin.hasBeenBuiltOnce && compilation.modifiedFiles) {
           for (const filePath of compilation.modifiedFiles) {
-            console.log(this.options.confImgPath, filePath, filePath.includes(this.options.confImgPath))
             if (filePath.includes(this.options.confImgPath)) {
               hasChanges = true
             }
@@ -92,7 +91,7 @@ class WebpackImageSizesPlugin {
         }
 
         if (WebpackImageSizesPlugin.hasBeenBuiltOnce && !hasChanges) {
-          console.log(`✅ No changes detected in ${this.options.confImgPath}`)
+          this.log('log', `✅ No changes detected in ${this.options.confImgPath}`)
 
           if (callback) {
             callback()

--- a/config/webpack-image-sizes-plugin.js
+++ b/config/webpack-image-sizes-plugin.js
@@ -35,16 +35,16 @@ class WebpackImageSizesPlugin {
    */
   constructor(options = {}) {
     this.options = {
-      confImgPath: options.confImgPath || 'assets/conf-img',
-      sizesSubdir: options.sizesSubdir || 'sizes',
-      tplSubdir: options.tplSubdir || 'tpl',
-      outputImageLocations: options.outputImageLocations || 'image-locations.json',
-      outputImageSizes: options.outputImageSizes || 'image-sizes.json',
-      generateDefaultImages: options.generateDefaultImages || false,
-      defaultImageSource: options.defaultImageSource || 'src/img/static/default.jpg',
-      defaultImagesOutputDir: options.defaultImagesOutputDir || 'dist/images',
-      defaultImageFormat: options.defaultImageFormat || 'jpg',
-      silence: options.silence || false,
+      confImgPath: 'assets/conf-img',
+      sizesSubdir: 'sizes',
+      tplSubdir: 'tpl',
+      outputImageLocations: 'image-locations.json',
+      outputImageSizes: 'image-sizes.json',
+      generateDefaultImages: false,
+      defaultImageSource: 'src/img/static/default.jpg',
+      defaultImagesOutputDir: 'dist/images',
+      defaultImageFormat: 'jpg',
+      silence: false,
       ...options,
     }
   }

--- a/config/webpack-image-sizes-plugin.js
+++ b/config/webpack-image-sizes-plugin.js
@@ -149,7 +149,7 @@ class WebpackImageSizesPlugin {
       runGeneration(compiler, callback)
     })
 
-    // Add directories to wat
+    // Add directories to watch
     compiler.hooks.compilation.tap('WebpackImageSizesPlugin', (compilation) => {
       // Watch configuration directories
       if (fs.existsSync(sizesPath)) {

--- a/config/webpack-image-sizes-plugin.js
+++ b/config/webpack-image-sizes-plugin.js
@@ -47,6 +47,8 @@ class WebpackImageSizesPlugin {
       silence: false,
       ...options,
     }
+
+    this.hasBeenBuiltOnce = false
   }
 
   /**
@@ -82,7 +84,7 @@ class WebpackImageSizesPlugin {
 
         // Check if there are any changes in the conf-img directory
         // Assumes that no modified files means the start of the build (yarn start || yarn build)
-        if (WebpackImageSizesPlugin.hasBeenBuiltOnce && compilation.modifiedFiles) {
+        if (this.hasBeenBuiltOnce && compilation.modifiedFiles) {
           for (const filePath of compilation.modifiedFiles) {
             if (filePath.includes(this.options.confImgPath)) {
               hasChanges = true
@@ -90,7 +92,7 @@ class WebpackImageSizesPlugin {
           }
         }
 
-        if (WebpackImageSizesPlugin.hasBeenBuiltOnce && !hasChanges) {
+        if (this.hasBeenBuiltOnce && !hasChanges) {
           this.log('log', `✅ No changes detected in ${this.options.confImgPath}`)
 
           if (callback) {
@@ -100,7 +102,7 @@ class WebpackImageSizesPlugin {
           return
         }
 
-        WebpackImageSizesPlugin.hasBeenBuiltOnce = true
+        this.hasBeenBuiltOnce = true
 
         this.log('log', '🔧 Starting WebpackImageSizesPlugin generation...')
 
@@ -543,11 +545,6 @@ class WebpackImageSizesPlugin {
     }
   }
 }
-
-// ----
-// static properties
-// ----
-WebpackImageSizesPlugin.hasBeenBuiltOnce = false
 
 // ----
 // export

--- a/config/webpack-image-sizes-plugin.js
+++ b/config/webpack-image-sizes-plugin.js
@@ -150,19 +150,16 @@ class WebpackImageSizesPlugin {
     })
 
     // Add directories to watch
-    compiler.hooks.afterEnvironment.tap('WebpackImageSizesPlugin', () => {
-      // Add directories to watched dependencies
-      compiler.hooks.compilation.tap('WebpackImageSizesPlugin', (compilation) => {
-        // Watch configuration directories
-        if (fs.existsSync(sizesPath)) {
-          compilation.contextDependencies.add(sizesPath)
-          this.log('log', '📁 Added sizes directory to watch dependencies')
-        }
-        if (fs.existsSync(tplPath)) {
-          compilation.contextDependencies.add(tplPath)
-          this.log('log', '📁 Added tpl directory to watch dependencies')
-        }
-      })
+    compiler.hooks.compilation.tap('WebpackImageSizesPlugin', (compilation) => {
+      // Watch configuration directories
+      if (fs.existsSync(sizesPath)) {
+        compilation.contextDependencies.add(sizesPath)
+        this.log('log', '📁 Added sizes directory to watch dependencies')
+      }
+      if (fs.existsSync(tplPath)) {
+        compilation.contextDependencies.add(tplPath)
+        this.log('log', '📁 Added tpl directory to watch dependencies')
+      }
     })
   }
 

--- a/src/scss/03-base/_fonts.scss
+++ b/src/scss/03-base/_fonts.scss
@@ -25,7 +25,7 @@
  *          ...
  */
 
-@use "node_modules/@fontsource/poppins/scss/mixins" as Poppins;
+@use "../../../node_modules/@fontsource/poppins/scss/mixins" as Poppins;
 
 @include Poppins.faces($weights: (300, 400, 500, 700), $styles: normal);
 @include Poppins.faces($weights: (300, 400, 500, 700), $styles: italic);


### PR DESCRIPTION
Prevent webpack image sizes plugin to be called too many times

## Summary by Sourcery

Optimize the WebpackImageSizesPlugin to avoid repeated invocations by tracking build state and file changes, streamline its initialization logic, and correct the SCSS import path for Poppins font mixins.

Enhancements:
- Throttle image sizes generation by tracking build state and skipping runs when no config images change
- Leverage compilation.modifiedFiles in watch mode to detect changes and conditionally invoke the plugin
- Refactor option initialization to apply static defaults before merging custom settings
- Remove redundant path resolutions by extracting compiler context once in the apply hook
- Introduce a static hasBeenBuiltOnce flag to track first build and prevent unnecessary re-generation
- Update watchRun hook signature to use compilation context for change detection