### PR TITLE
fix focus to use default focus to leave the browser's default focus sufficiently contrasted on all interactive elements

### DIFF
--- a/src/scss/02-tools/_m-select-custom.scss
+++ b/src/scss/02-tools/_m-select-custom.scss
@@ -52,17 +52,4 @@
 	&:hover {
 		border-color: color.adjust($color-grey-500, $lightness: -10%);
 	}
-
-	// Focus style
-	&:focus {
-		color: color.adjust($color-text, $lightness: -10%);
-		border-color: color.adjust($color-grey-500, $lightness: -20%);
-		outline: none;
-		box-shadow: 0 0 1px 3px rgba(59, 153, 252, .7);
-		box-shadow: 0 0 0 3px -moz-mac-focusring;
-
-		option {
-			outline: none;
-		}
-	}
 }

--- a/src/scss/04-utilities/_focus.scss
+++ b/src/scss/04-utilities/_focus.scss
@@ -6,8 +6,7 @@ html {
 	textarea,
 	[tabindex] {
 		&:focus-visible {
-			outline: 2px solid currentColor;
-			outline-offset: .5rem;
+			outline-offset: .2rem;
 		}
 	}
 }

--- a/src/scss/04-utilities/_seo.scss
+++ b/src/scss/04-utilities/_seo.scss
@@ -1,16 +1,4 @@
-%focus-seo-container {
-	&:has(:focus-visible) {
-		outline: 2px solid currentColor;
-		outline-offset: .5rem;
-	}
-
-	*:focus {
-		outline: none;
-	}
-}
-
 %seo-container {
-	@extend %focus-seo-container;
 	position: relative;
 	z-index: 1;
 	cursor: pointer;

--- a/src/scss/05-components/_skip-links.scss
+++ b/src/scss/05-components/_skip-links.scss
@@ -22,10 +22,6 @@
 		font-size: 13px;
 		color: $color-text;
 		text-decoration: none;
-
-		&:focus {
-			outline-offset: 3px;
-		}
 	}
 
 	&:focus-within {

--- a/src/scss/06-blocks/core/_audio.scss
+++ b/src/scss/06-blocks/core/_audio.scss
@@ -5,10 +5,5 @@
 		&::-webkit-media-controls-panel {
 			background-color: $color-primary;
 		}
-
-		&:focus {
-			outline: 2px solid $color-primary;
-			outline-offset: 5px;
-		}
 	}
 }


### PR DESCRIPTION
Suite à de nombreux retours sur des audits a11y, il vaut mieux garder le focus natif navigateur qui automatiquement va garder son anneau de focus suffisamment contrasté par rapport à la couleur de fond. Webkit utilise par exemple `webkit-focus-ring-color` 

Le fait d'avoir un currentColor pose souvent des soucis par exemple dans le cas d'un élément blanc sur fond de couleur, donc le focus n'est pas visible, et il faut penser à apporter des surcharges au cas par cas. 

C'est typiquement les soucis qu'on a sur plusieurs projets.

On garde également le focus uniquement sur le lien présent dans un card et non la card complète, ce qui apporte plus de contexte et aussi parfois on a des taxo qui sont cliquables dans les cards et donc le focus n'est pas visible.

On se contente juste de jouer avec l'offset et la taille de l'outline au besoin