### PR TITLE
Fix ari image not display in editor

### DIFF
--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -2,9 +2,18 @@
 
 /* Customize BFFEditorSettings in inc/Services/Editor.php or with `bff_editor_custom_settings` filter (see readme). */
 
+import lazySizes from 'lazysizes'
 import domReady from '@wordpress/dom-ready'
 import { addFilter } from '@wordpress/hooks'
 import { unregisterBlockStyle, getBlockVariations, unregisterBlockVariation } from '@wordpress/blocks'
+
+/**
+ * LazySizes configuration
+ * https://github.com/aFarkas/lazysizes/#js-api---options
+ */
+lazySizes.cfg.nativeLoading = {
+	setLoadingAttribute: false,
+}
 
 // Native Gutenberg
 domReady(() => {


### PR DESCRIPTION
Fix des images ARI qui n'étaient pas affichées dans l'éditeur.

Un oubli a été omis dans la PR : https://github.com/BeAPI/beapi-frontend-framework/pull/468

Remarqué dans le cadre d'un projet

## Summary by Sourcery

Bug Fixes:
- Ensure ARI images are properly displayed within the editor interface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to the editor bundle: it only adds LazySizes initialization/configuration and should not affect frontend rendering, but could alter how image `loading` attributes are handled in the editor.
> 
> **Overview**
> Fixes missing lazy-loading setup in the Gutenberg editor by importing `lazysizes` in `src/js/editor.js` and applying a `nativeLoading` configuration (`setLoadingAttribute: false`).
> 
> This aligns editor behavior with the frontend bundle (which already loads LazySizes) so lazy-loaded images render correctly while avoiding LazySizes mutating the `loading` attribute in-editor.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49cc352c0063f3313da1abc00c971a94fe56a520. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->