### PR TITLE
fix the focus

### DIFF
--- a/src/scss/02-tools/_m-hover.scss
+++ b/src/scss/02-tools/_m-hover.scss
@@ -42,7 +42,7 @@
  *
  */
 @mixin hover($onlyNoTouch: null, $additionalSelectors: null) {
-	$selectors: "&:hover", "&:active", "&:focus";
+	$selectors: "&:hover", "&:active", "&:focus-visible";
 
 	@if ($additionalSelectors) {
 		@if (meta.type-of($additionalSelectors) == "string") {


### PR DESCRIPTION
Fix du focus du mixin hover, pour rester cohérent avec le focus de base qui est focus-visible : https://github.com/BeAPI/beapi-frontend-framework/blob/master/src/scss/04-utilities/_focus.scss#L8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small selector change limited to hover/focus styling; may slightly alter keyboard-focus behavior where `:focus` previously applied but `:focus-visible` does not.
> 
> **Overview**
> Updates the `hover` mixin in `_m-hover.scss` to use `&:focus-visible` (instead of `&:focus`) alongside `:hover`/`:active`, aligning its focus behavior with the project’s `focus-visible` utility and reducing unwanted focus styles for non-keyboard interactions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef4a0c43c84e75ebb10ad1bd7a5afc50a94c293d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->