### PR TITLE
refactor(assets): align dist filenames with webpack manifest

### DIFF
--- a/config/plugins.js
+++ b/config/plugins.js
@@ -52,6 +52,12 @@ module.exports = {
 				defaultImageFormat: 'jpg', // Generated image format (jpg, png, webp, avif)
 				silence: true, // Suppress console output
 			}),
+			new MiniCssExtractPlugin({
+				filename: '[name].css',
+			}),
+			new WebpackManifestPlugin({
+				fileName: 'assets.json',
+			}),
 		]
 
 		if (mode === 'production') {
@@ -59,20 +65,6 @@ module.exports = {
 				new BundleAnalyzerPlugin({
 					analyzerMode: 'json',
 					generateStatsFile: true,
-				})
-			)
-			plugins.push(
-				new WebpackManifestPlugin({
-					fileName: 'assets.json',
-				}),
-				new MiniCssExtractPlugin({
-					filename: '[name].[contenthash:8].min.css',
-				})
-			)
-		} else {
-			plugins.push(
-				new MiniCssExtractPlugin({
-					filename: '[name].css',
 				})
 			)
 		}

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -8,7 +8,7 @@ module.exports = merge(common, {
 	mode: mode,
 	stats: 'minimal',
 	output: {
-		filename: '[name]-min.js',
+		filename: '[name].js',
 	},
 	optimization: {
 		concatenateModules: true,

--- a/inc/Services/Assets.php
+++ b/inc/Services/Assets.php
@@ -218,10 +218,23 @@ class Assets implements Service {
 	}
 
 	/**
-	 * Change login CSS URL
-	 * @return string
+	 * Point the login page stylesheet to the built CSS in `dist/` when available.
+	 *
+	 * @param string $stylesheet_path Default path relative to the theme root (from `wp_login_page_theme_css`).
+	 *
+	 * @return string Path relative to the theme root.
 	 */
-	public function login_stylesheet_uri(): string {
-		return 'dist/' . $this->get_min_file( 'login' );
+	public function login_stylesheet_uri( string $stylesheet_path = '' ): string {
+		$file = $this->get_min_file( 'login' );
+
+		if ( ! empty( $file ) && file_exists( \get_theme_file_path( '/dist/' . $file ) ) ) {
+			return 'dist/' . $file;
+		}
+
+		if ( file_exists( \get_theme_file_path( '/dist/login.css' ) ) ) {
+			return 'dist/login.css';
+		}
+
+		return $stylesheet_path;
 	}
 }

--- a/inc/Services/Assets.php
+++ b/inc/Services/Assets.php
@@ -55,13 +55,11 @@ class Assets implements Service {
 		if ( is_admin() ) {
 			return;
 		}
+
 		$theme = wp_get_theme();
 
-		// Do not add a versioning query param in assets URLs if minified
-		$version = $this->is_minified() ? null : $theme->get( 'Version' );
-
-		// Js
-		$file       = $this->is_minified() ? $this->get_min_file( 'js' ) : 'app.js';
+		// JavaScript
+		$file       = $this->get_min_file( 'js' );
 		$asset_data = $this->get_asset_data( $file );
 		$this->assets_tools->register_script(
 			'scripts',
@@ -80,15 +78,15 @@ class Assets implements Service {
 			),
 		);
 
-		// CSS
-		wp_register_style( 'theme-style', get_stylesheet_uri(), [], $version );
+		// Styles
+		wp_register_style( 'theme-style', get_stylesheet_uri(), [], $theme->get( 'Version' ) );
 	}
 
 	/**
 	 * Enqueue the scripts
 	 */
 	public function enqueue_scripts(): void {
-		// JS
+		// JavaScript
 		$this->assets_tools->enqueue_script( 'scripts' );
 	}
 
@@ -96,24 +94,23 @@ class Assets implements Service {
 	 * Enqueue the styles
 	 */
 	public function enqueue_styles(): void {
-		// CSS
+		// Styles
 		$this->assets_tools->enqueue_style( 'theme-style' );
 	}
 
 	/**
-	 * The stylesheet uri based on the dev or not constant
+	 * Point the theme stylesheet to the built CSS in `dist/` when `assets.json` is present.
 	 *
-	 * @param string $stylesheet_uri
+	 * @param string $stylesheet_uri Default theme stylesheet URI.
 	 *
 	 * @return string
 	 * @author Nicolas Juen
 	 */
 	public function stylesheet_uri( string $stylesheet_uri ): string {
-		if ( $this->is_minified() ) {
-			$file = $this->get_min_file( 'css' );
-			if ( ! empty( $file ) && file_exists( \get_theme_file_path( '/dist/' . $file ) ) ) {
-				return \get_theme_file_uri( '/dist/' . $file );
-			}
+		$file = $this->get_min_file( 'css' );
+
+		if ( ! empty( $file ) && file_exists( \get_theme_file_path( '/dist/' . $file ) ) ) {
+			return \get_theme_file_uri( '/dist/' . $file );
 		}
 
 		if ( file_exists( \get_theme_file_path( '/dist/app.css' ) ) ) {
@@ -124,9 +121,9 @@ class Assets implements Service {
 	}
 
 	/**
-	 * Return JS/CSS .min file based on assets.json
+	 * Return the compiled asset filename for a type from `assets.json`.
 	 *
-	 * @param string $type
+	 * @param string $type Asset type key (e.g. `js`, `css`, `editor.js`).
 	 *
 	 * @return string
 	 */
@@ -185,7 +182,7 @@ class Assets implements Service {
 	 * Asset data are produced by the webpack dependencies extraction plugin. They contain for each asset the list of
 	 * dependencies use by the asset and a hash representing the current version of the asset.
 	 *
-	 * @param string $file The asset name including its extension, eg: app.js, app-min.js
+	 * @param string $file The asset name including its extension, e.g. `app.js`.
 	 *
 	 * @return array{dependencies: string[], version:string} The asset data if available or an array with the default keys.
 	 */
@@ -202,30 +199,22 @@ class Assets implements Service {
 			return $empty_asset_data;
 		}
 
-		if ( isset( $cache_data[ $file ] ) ) {
-			return $cache_data[ $file ];
+		$cache_key = $file;
+
+		if ( isset( $cache_data[ $cache_key ] ) ) {
+			return $cache_data[ $cache_key ];
 		}
 
-		$filename = strtok( $file, '.' );
-		$file     = sprintf( '/dist/%s.asset.php', $filename );
-		if ( ! file_exists( \get_theme_file_path( $file ) ) ) {
-			$cache_data[ $file ] = $empty_asset_data;
-			return $cache_data[ $file ];
+		$filename  = strtok( $file, '.' );
+		$asset_php = sprintf( '/dist/%s.asset.php', $filename );
+		if ( ! file_exists( \get_theme_file_path( $asset_php ) ) ) {
+			$cache_data[ $cache_key ] = $empty_asset_data;
+			return $cache_data[ $cache_key ];
 		}
 
-		$cache_data[ $file ] = require \get_theme_file_path( $file );
+		$cache_data[ $cache_key ] = require \get_theme_file_path( $asset_php );
 
-		return $cache_data[ $file ];
-	}
-
-	/**
-	 * Check if we are on minified environment.
-	 *
-	 * @return bool
-	 * @author Nicolas JUEN
-	 */
-	public function is_minified(): bool {
-		return ( ! defined( 'SCRIPT_DEBUG' ) || SCRIPT_DEBUG === false );
+		return $cache_data[ $cache_key ];
 	}
 
 	/**
@@ -233,6 +222,6 @@ class Assets implements Service {
 	 * @return string
 	 */
 	public function login_stylesheet_uri(): string {
-		return $this->is_minified() ? 'dist/' . $this->get_min_file( 'login' ) : 'dist/login.css';
+		return 'dist/' . $this->get_min_file( 'login' );
 	}
 }

--- a/inc/Services/Assets.php
+++ b/inc/Services/Assets.php
@@ -59,7 +59,7 @@ class Assets implements Service {
 		$theme = wp_get_theme();
 
 		// JavaScript
-		$file       = $this->get_min_file( 'js' );
+		$file       = $this->get_min_file( 'js' ) ?: 'app.js';
 		$asset_data = $this->get_asset_data( $file );
 		$this->assets_tools->register_script(
 			'scripts',

--- a/inc/Services/Editor.php
+++ b/inc/Services/Editor.php
@@ -61,7 +61,7 @@ class Editor implements Service {
 	 * editor style
 	 */
 	private function style(): void {
-		$file = $this->assets->is_minified() ? $this->assets->get_min_file( 'editor.css' ) : 'editor.css';
+		$file = $this->assets->get_min_file( 'editor.css' );
 
 		/**
 		 * Do not enqueue a inexistant file on admin

--- a/inc/Services/Editor.php
+++ b/inc/Services/Editor.php
@@ -61,7 +61,7 @@ class Editor implements Service {
 	 * editor style
 	 */
 	private function style(): void {
-		$file = $this->assets->get_min_file( 'editor.css' );
+		$file = $this->assets->get_min_file( 'editor.css' ) ?: 'editor.css';
 
 		/**
 		 * Do not enqueue a inexistant file on admin

--- a/inc/Services/Editor.php
+++ b/inc/Services/Editor.php
@@ -77,7 +77,7 @@ class Editor implements Service {
 	 * Editor script
 	 */
 	public function admin_editor_script(): void {
-		$file     = $this->assets->get_min_file( 'editor.js' );
+		$file     = $this->assets->get_min_file( 'editor.js' ) ?: 'editor.js';
 		$filepath = 'dist/' . $file;
 
 		if ( ! file_exists( get_theme_file_path( $filepath ) ) ) {

--- a/inc/Services/Editor.php
+++ b/inc/Services/Editor.php
@@ -77,7 +77,7 @@ class Editor implements Service {
 	 * Editor script
 	 */
 	public function admin_editor_script(): void {
-		$file     = $this->assets->is_minified() ? $this->assets->get_min_file( 'editor.js' ) : 'editor.js';
+		$file     = $this->assets->get_min_file( 'editor.js' );
 		$filepath = 'dist/' . $file;
 
 		if ( ! file_exists( get_theme_file_path( $filepath ) ) ) {


### PR DESCRIPTION
- Use stable output names in production (app.js, [name].css) and same MiniCssExtract + WebpackManifestPlugin in all modes.
- Register theme JS/CSS from assets.json only; remove is_minified() and SCRIPT_DEBUG-based branching.
- Fix get_asset_data() static cache to key by the requested filename.
- Update PHPDoc and inline comments to match the new flow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches build outputs and runtime asset URL resolution; a mismatch between webpack manifest entries and expected keys could break script/style loading in production.
> 
> **Overview**
> Build output is changed to use *stable* production filenames (`[name].js`, `[name].css`) and to always emit `dist/assets.json` via `WebpackManifestPlugin`, with `MiniCssExtractPlugin` configured consistently across modes.
> 
> Theme PHP asset resolution is refactored to rely on `assets.json` for JS/CSS/editor/login filenames (falling back to `app.js`/`app.css`/`login.css` when missing), removes `is_minified()`/`SCRIPT_DEBUG` branching, fixes `get_asset_data()` caching to key by the requested filename, and updates `stylesheet_uri`/login CSS filters accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b44a96d00087a608136d50a6c5543d04568b05f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->