### PR TITLE
Enhance SCSS imports and update loaders configuration to support package-style imports

### DIFF
--- a/config/loaders.js
+++ b/config/loaders.js
@@ -92,6 +92,8 @@ module.exports = {
 								let obj = {
 									quietDeps: true,
 									sourceMap: true,
+									// Resolve package-style imports (e.g. @fontsource-variable/...) like Node does
+									loadPaths: [nodeModulesPath],
 								}
 
 								if (isProduction && isEditor(loaderContext)) {

--- a/src/scss/03-base/_fonts.scss
+++ b/src/scss/03-base/_fonts.scss
@@ -17,20 +17,20 @@
  *
  *      2 - Declare font-face :
  *          // For Classic font
- *          @use "../../../node_modules/@fontsource-utils/scss/src/mixins" as fontsource;
- *          @use "../../../node_modules/@fontsource/myFont/scss/mixins" as MyFont;
+ *          @use "@fontsource-utils/scss/src/mixins" as fontsource;
+ *          @use "@fontsource/myFont/scss/mixins" as MyFont;
  *          @include fontsource.faces($metadata: MyFont.$metadata, $weights: (400, 700));
  *          ...
  *
  *          // For Variable font
- *          @use "../../../node_modules/@fontsource-utils/scss/src/mixins" as fontsource;
- *          @use "../../../node_modules/@fontsource-variable/myFont/scss/mixins" as MyFont;
+ *          @use "@fontsource-utils/scss/src/mixins" as fontsource;
+ *          @use "@fontsource-variable/myFont/scss/mixins" as MyFont;
  *          @include fontsource.faces($metadata: MyFont.$metadata, $axes: wght);
  *          ...
  */
 
-@use "../../../node_modules/@fontsource-utils/scss/src/mixins" as fontsource;
-@use "../../../node_modules/@fontsource/poppins/scss/mixins" as Poppins;
+@use "@fontsource-utils/scss/src/mixins" as fontsource;
+@use "@fontsource/poppins/scss/mixins" as Poppins;
 
 @include fontsource.faces($metadata: Poppins.$metadata, $weights: (300, 400, 500, 700), $styles: normal);
 @include fontsource.faces($metadata: Poppins.$metadata, $weights: (300, 400, 500, 700), $styles: italic);


### PR DESCRIPTION
Fix des imports des libs CSS pour s'épargner le `../../node_modules....`

Utile pour `depcheck` car sinon il ne voit pas que les libs sont utilisées et remonte en erreur en disant qu'elles ne sont pas utilisées : https://www.npmjs.com/package/depcheck

<img width="482" height="102" alt="Capture d’écran 2026-04-28 à 11 50 26" src="https://github.com/user-attachments/assets/68b6abfb-06cb-4267-800d-7eb2b947bfdb" />  

___

@francoistibo Il faudrait peut-être faire des tickets sur les projets qui contiennent cet import static ?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0bf1b4082936709c18f6babfc77da2de9d0e0d6d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->