### PR TITLE
chore: remove unused style-loader dependency from package.json and yarn.lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "sass": "^1.85.1",
     "sass-loader": "^16.0.5",
     "sharp": "^0.34.2",
-    "style-loader": "^2.0.0",
     "stylelint": "^14.13.0",
     "stylelint-config-recess-order": "^3.0.0",
     "stylelint-scss": "^4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2294,7 +2294,6 @@ __metadata:
     sass: "npm:^1.85.1"
     sass-loader: "npm:^16.0.5"
     sharp: "npm:^0.34.2"
-    style-loader: "npm:^2.0.0"
     stylelint: "npm:^14.13.0"
     stylelint-config-recess-order: "npm:^3.0.0"
     stylelint-scss: "npm:^4.3.0"
@@ -10722,18 +10721,6 @@ __metadata:
     "@tokenizer/token": "npm:^0.3.0"
     peek-readable: "npm:^4.1.0"
   checksum: 10/98fba564d3830202aa3a6bcd5ccaf2cbd849bd87ae79ece91d337e1913916705a8e633c9577138d030a984f8ec987dea51807e01252f995cf5e183fdea35eb2b
-  languageName: node
-  linkType: hard
-
-"style-loader@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "style-loader@npm:2.0.0"
-  dependencies:
-    loader-utils: "npm:^2.0.0"
-    schema-utils: "npm:^3.0.0"
-  peerDependencies:
-    webpack: ^4.0.0 || ^5.0.0
-  checksum: 10/129f8d7124bc46ece4363992a38329c6879356298338c8e448e70ec76eeec83f5214339814863324fe0089286bf6860a1971b9a2247718474db609ac6f04990a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Suppression d'une dépendance non utilisée, remontée par `depcheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup: only removes an unused dev dependency and its lockfile entry, with no runtime or business-logic changes.
> 
> **Overview**
> Removes the unused `style-loader` dev dependency from `package.json` and deletes its corresponding entry from `yarn.lock` to keep the dependency tree clean.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f4deccd6b29f29a274b049e0f9c5ab2ea795ada. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->