### PR TITLE
Feat/depcheck

### DIFF
--- a/.depcheckrc
+++ b/.depcheckrc
@@ -1,0 +1,29 @@
+# depcheck — https://github.com/depcheck/depcheck
+#
+# Ignore-only setup: depcheck's webpack special does not scan webpack.dev.js / loaders.js naming,
+# and there is no Stylelint special for .stylelintrc. Listed packages are used via Webpack,
+# Stylelint config, or SCSS paths—not plain JS imports.
+
+ignores:
+  - "@wordpress/stylelint-config"
+  - stylelint-config-recess-order
+  - stylelint-scss
+  - postcss-scss
+  - css-loader
+  - cssnano
+  - esbuild-loader
+  - imagemin
+  - imagemin-gifsicle
+  - imagemin-jpegtran
+  - imagemin-optipng
+  - imagemin-svgo
+  - postcss
+  - postcss-import
+  - postcss-loader
+  - postcss-preset-env
+  - postcss-pxtorem
+  - postcss-sort-media-queries
+  - sass-loader
+  - svgo
+  - svgo-loader
+  - webpack-cli

--- a/config/loaders.js
+++ b/config/loaders.js
@@ -92,6 +92,8 @@ module.exports = {
 								let obj = {
 									quietDeps: true,
 									sourceMap: true,
+									// Resolve package-style imports (e.g. @fontsource-variable/...) like Node does
+									loadPaths: [nodeModulesPath],
 								}
 
 								if (isProduction && isEditor(loaderContext)) {

--- a/config/webpack-theme-json-plugin.js
+++ b/config/webpack-theme-json-plugin.js
@@ -1,8 +1,5 @@
-const chalk = require('chalk')
 const path = require('path')
 const fs = require('fs')
-
-const logId = '[' + chalk.blue('WebpackThemeJsonPlugin') + ']'
 
 class WebpackThemeJsonPlugin {
 	/**
@@ -32,7 +29,7 @@ class WebpackThemeJsonPlugin {
 	/**
 	 * apply
 	 */
-	apply() {}
+	apply() { }
 
 	/**
 	 * Generate theme json file
@@ -51,21 +48,21 @@ class WebpackThemeJsonPlugin {
 					json = JSON.parse(json)
 				} catch (e) {
 					// eslint-disable-next-line no-console
-					console.error(logId, 'Error parsing JSON file:', file.name)
+					console.error('WebpackThemeJsonPlugin: Error parsing JSON file:', file.name)
 				}
 
 				if (isPlainObject(json)) {
 					extend(true, themeJson, json)
 				} else {
 					// eslint-disable-next-line no-console
-					console.error(logId, 'JSON file is not a plain object:', file.name)
+					console.error('WebpackThemeJsonPlugin: JSON file is not a plain object:', file.name)
 				}
 			}
 		})
 
 		fs.writeFileSync(this._output, JSON.stringify(themeJson, null, 2))
 		// eslint-disable-next-line no-console
-		console.log(logId, 'JSON files successfully generated !')
+		console.log('WebpackThemeJsonPlugin: JSON files successfully generated !')
 
 		return this
 	}
@@ -116,7 +113,7 @@ class WebpackThemeJsonPlugin {
 			jsonFile = JSON.parse(jsonFile)
 		} catch (e) {
 			// eslint-disable-next-line no-console
-			console.error(logId, 'Error parsing JSON file:', this._output)
+			console.error('WebpackThemeJsonPlugin: Error parsing JSON file:', this._output)
 			return this
 		}
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "sass": "^1.85.1",
     "sass-loader": "^16.0.5",
     "sharp": "^0.34.2",
-    "style-loader": "^2.0.0",
     "stylelint": "^14.13.0",
     "stylelint-config-recess-order": "^3.0.0",
     "stylelint-scss": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint:css": "node_modules/.bin/stylelint \"src/scss/**/*.scss\"",
     "lint:js": "node_modules/.bin/eslint \"src/js/**/*.js\"",
     "lint": "node_modules/.bin/concurrently \"npx yarn lint:css\" \"npx yarn lint:js\"",
-    "bundle-report": "yarn build && yarn webpack-bundle-analyzer dist/stats.json"
+    "bundle-report": "yarn build && yarn webpack-bundle-analyzer dist/stats.json",
+    "depcheck": "npx depcheck"
   },
   "license": "GPL-2.0",
   "dependencies": {

--- a/src/scss/03-base/_fonts.scss
+++ b/src/scss/03-base/_fonts.scss
@@ -17,20 +17,20 @@
  *
  *      2 - Declare font-face :
  *          // For Classic font
- *          @use "../../../node_modules/@fontsource-utils/scss/src/mixins" as fontsource;
- *          @use "../../../node_modules/@fontsource/myFont/scss/mixins" as MyFont;
+ *          @use "@fontsource-utils/scss/src/mixins" as fontsource;
+ *          @use "@fontsource/myFont/scss/mixins" as MyFont;
  *          @include fontsource.faces($metadata: MyFont.$metadata, $weights: (400, 700));
  *          ...
  *
  *          // For Variable font
- *          @use "../../../node_modules/@fontsource-utils/scss/src/mixins" as fontsource;
- *          @use "../../../node_modules/@fontsource-variable/myFont/scss/mixins" as MyFont;
+ *          @use "@fontsource-utils/scss/src/mixins" as fontsource;
+ *          @use "@fontsource-variable/myFont/scss/mixins" as MyFont;
  *          @include fontsource.faces($metadata: MyFont.$metadata, $axes: wght);
  *          ...
  */
 
-@use "../../../node_modules/@fontsource-utils/scss/src/mixins" as fontsource;
-@use "../../../node_modules/@fontsource/poppins/scss/mixins" as Poppins;
+@use "@fontsource-utils/scss/src/mixins" as fontsource;
+@use "@fontsource/poppins/scss/mixins" as Poppins;
 
 @include fontsource.faces($metadata: Poppins.$metadata, $weights: (300, 400, 500, 700), $styles: normal);
 @include fontsource.faces($metadata: Poppins.$metadata, $weights: (300, 400, 500, 700), $styles: italic);

--- a/src/scss/03-base/_fonts.scss
+++ b/src/scss/03-base/_fonts.scss
@@ -17,14 +17,14 @@
  *
  *      2 - Declare font-face :
  *          // For Classic font
- *          @use "@fontsource-utils/scss/src/mixins" as fontsource;
- *          @use "@fontsource/myFont/scss/mixins" as MyFont;
+ *          import the utils mixins from "@fontsource-utils/scss/src/mixins" as fontsource;
+ *          import the font mixins from "@fontsource/myFont/scss/mixins" as MyFont;
  *          @include fontsource.faces($metadata: MyFont.$metadata, $weights: (400, 700));
  *          ...
  *
  *          // For Variable font
- *          @use "@fontsource-utils/scss/src/mixins" as fontsource;
- *          @use "@fontsource-variable/myFont/scss/mixins" as MyFont;
+ *          import the utils mixins from "@fontsource-utils/scss/src/mixins" as fontsource;
+ *          import the font mixins from "@fontsource-variable/myFont/scss/mixins" as MyFont;
  *          @include fontsource.faces($metadata: MyFont.$metadata, $axes: wght);
  *          ...
  */

--- a/src/scss/editor.scss
+++ b/src/scss/editor.scss
@@ -77,11 +77,11 @@ variables.$entry-file-name: "editor";
  * == Contains styles for gutenberg patterns.
  */
 
-// @use "07-patterns/...";
+// Import patterns from "07-patterns/...";
 
 /**
  * Vendor
  * == Plugins or libraries custom styles.
  */
 
-// @use "10-vendor/...";
+// Import vendor styles from "10-vendor/...";

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -84,7 +84,7 @@ variables.$entry-file-name: "style";
  * == Contains styles for gutenberg patterns.
  */
 
-// @use "07-patterns/...";
+// Import patterns from "07-patterns/...";
 
 /**
  * Template parts
@@ -108,4 +108,4 @@ variables.$entry-file-name: "style";
  * == Plugins or libraries custom styles.
  */
 
-// @use "10-vendor/...";
+// Import vendor styles from "10-vendor/...";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2294,7 +2294,6 @@ __metadata:
     sass: "npm:^1.85.1"
     sass-loader: "npm:^16.0.5"
     sharp: "npm:^0.34.2"
-    style-loader: "npm:^2.0.0"
     stylelint: "npm:^14.13.0"
     stylelint-config-recess-order: "npm:^3.0.0"
     stylelint-scss: "npm:^4.3.0"
@@ -2678,9 +2677,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001688, caniuse-lite@npm:^1.0.30001702":
-  version: 1.0.30001712
-  resolution: "caniuse-lite@npm:1.0.30001712"
-  checksum: 10/1831ac3260b9657c5a0236d21c02bea6a6b88fd67a451a0ff166d27da17c95ab398c5721e08aeb24f766bced1d38f562f07c8de84e91a10a065808e83835e89e
+  version: 1.0.30001791
+  resolution: "caniuse-lite@npm:1.0.30001791"
+  checksum: 10/0ec6ef60ca9f5da3da37a57c8b7b645878b6aca406eb5b569dda0bdfa518fe83320e3e2e9e25450a40a8f34854c1537c287f8bd107830aa6f39c3018f98fe408
   languageName: node
   linkType: hard
 
@@ -10722,18 +10721,6 @@ __metadata:
     "@tokenizer/token": "npm:^0.3.0"
     peek-readable: "npm:^4.1.0"
   checksum: 10/98fba564d3830202aa3a6bcd5ccaf2cbd849bd87ae79ece91d337e1913916705a8e633c9577138d030a984f8ec987dea51807e01252f995cf5e183fdea35eb2b
-  languageName: node
-  linkType: hard
-
-"style-loader@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "style-loader@npm:2.0.0"
-  dependencies:
-    loader-utils: "npm:^2.0.0"
-    schema-utils: "npm:^3.0.0"
-  peerDependencies:
-    webpack: ^4.0.0 || ^5.0.0
-  checksum: 10/129f8d7124bc46ece4363992a38329c6879356298338c8e448e70ec76eeec83f5214339814863324fe0089286bf6860a1971b9a2247718474db609ac6f04990a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Voir ici : https://www.notion.so/beapi/Test-Depcheck-C-dric-Avril-2026-3500865393b9809da840dcdb6fe429eb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the build toolchain (Webpack `sass-loader` resolution, SCSS imports, and devDependencies), which could break styling/builds if resolution differs between environments. No runtime/application logic changes beyond asset pipeline behavior.
> 
> **Overview**
> Adds `depcheck` tooling via a new `.depcheckrc` ignore list and a `yarn depcheck` script to better validate dependency usage in this Webpack/Stylelint-based setup.
> 
> Updates the SCSS pipeline to support package-style Sass imports by adding `sass-loader` `loadPaths` and switching Fontsource `@use` statements to module paths; also removes `style-loader` from devDependencies and simplifies `webpack-theme-json-plugin` logging by dropping `chalk`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f90784fdfec72e8142fd49148f7af8abab8d9f36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->