### PR TITLE
fix(editor): update asset loading for ACF V3 blocks in editor

### DIFF
--- a/inc/Services/Editor.php
+++ b/inc/Services/Editor.php
@@ -48,9 +48,21 @@ class Editor implements Service {
 		$this->register_custom_block_styles();
 
 		/**
-		 * Load editor JS for ADMIN
+		 * Load editor JS
+		 *
+		 * WP 6.3+ isolates the editor canvas in an iframe (`iframe[name="editor-canvas"]`).
+		 * This affects all blocks, but ACF Blocks V3 (`blockVersion: 3`) rely on it: their PHP
+		 * render templates (and ARI lazyload markup) are injected into that iframe on each preview
+		 * refresh — not into the admin shell where `enqueue_block_editor_assets` loads scripts.
+		 *
+		 * - `enqueue_block_editor_assets`  → admin shell only (outside the iframe).
+		 * - `enqueue_block_assets`         → iframe + front end (guarded with is_admin() below).
+		 *
+		 * lazySizes must therefore load via `enqueue_block_assets` to unveil `.lazyload` images
+		 * in ACF V3 block previews. Other blocks (e.g. ServerSideRender) may still work without
+		 * this, but ACF V3 previews will stay invisible until a DOM mutation triggers lazySizes.
 		 */
-		add_action( 'enqueue_block_editor_assets', [ $this, 'admin_editor_script' ] );
+		add_action( 'enqueue_block_assets', [ $this, 'admin_editor_script' ] );
 		/**
 		 * White list of gutenberg blocks
 		 */
@@ -77,6 +89,11 @@ class Editor implements Service {
 	 * Editor script
 	 */
 	public function admin_editor_script(): void {
+		// enqueue_block_assets also runs on the front end; skip outside wp-admin.
+		if ( ! is_admin() ) {
+			return;
+		}
+
 		$file     = $this->assets->get_min_file( 'editor.js' ) ?: 'editor.js';
 		$filepath = 'dist/' . $file;
 


### PR DESCRIPTION
Depuis WordPress 6.3, le canvas de l’éditeur Gutenberg est isolé dans une iframe (iframe[name="editor-canvas"]). Les blocs ACF V3 (blockVersion: 3) y injectent leurs templates PHP de rendu — y compris le markup lazyload ARI — à chaque rafraîchissement de prévisualisation.

Le script editor.js (qui charge lazySizes) était enregistré via enqueue_block_editor_assets, un hook qui ne cible que la coquille admin, en dehors de l’iframe. Résultat : les images .lazyload des blocs ACF V3 restaient invisibles dans l’éditeur jusqu’à une mutation DOM déclenchant lazySizes.

Ce correctif bascule l’enqueue vers enqueue_block_assets, qui s’exécute dans l’iframe et sur le front, avec un garde is_admin() pour éviter de charger le script côté public.

## Changements
- Remplacement du hook enqueue_block_editor_assets par enqueue_block_assets pour le chargement de editor.js
- Ajout d’un early return is_admin() dans admin_editor_script() (le nouveau hook s’exécute aussi en front)
- Documentation inline du comportement WP 6.3+ et de l’impact sur les blocs ACF V3 / lazySizes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and where editor JS loads in wp-admin and on the front end; incorrect guarding could enqueue admin editor scripts on the front end or miss them in the iframe.
> 
> **Overview**
> **Editor script loading** is moved from `enqueue_block_editor_assets` to `enqueue_block_assets` so `editor.js` (including lazySizes) runs inside the WP 6.3+ editor canvas iframe, where ACF Blocks V3 PHP previews and `.lazyload` markup actually render.
> 
> `admin_editor_script()` now **returns early when `! is_admin()`** so the same hook does not enqueue that bundle on the public site. Inline comments document why the iframe vs admin-shell split matters for ACF V3 previews.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87cbed92ccf68fbfb50f5dac9b961b16f26a989c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->