### PR TITLE
perf: cache assets.json manifest, drop WP <6.0 patterns backport, declare PHP/WP requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@
 
 ## Requirements
 
+### PHP & WordPress
+
+- PHP **8.3** or higher
+- WordPress **6.3** or higher
+
 ### Composer
 
 You need composer to autoload all your classes from the inc folder.

--- a/inc/Services/Assets.php
+++ b/inc/Services/Assets.php
@@ -132,14 +132,9 @@ class Assets implements Service {
 			return '';
 		}
 
-		if ( ! file_exists( \get_theme_file_path( '/dist/assets.json' ) ) ) {
-			return '';
-		}
+		$assets = $this->get_assets_manifest();
 
-		$json   = file_get_contents( \get_theme_file_path( '/dist/assets.json' ) ); //phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-		$assets = json_decode( $json, true );
-
-		if ( empty( $assets ) || JSON_ERROR_NONE !== json_last_error() ) {
+		if ( empty( $assets ) ) {
 			return '';
 		}
 
@@ -174,6 +169,41 @@ class Assets implements Service {
 		}
 
 		return $file;
+	}
+
+	/**
+	 * Read and decode the `dist/assets.json` manifest once per request.
+	 *
+	 * The manifest is requested several times per request (scripts registration,
+	 * `stylesheet_uri` filter, editor assets…): memoize the decoded content to
+	 * avoid repeated filesystem reads and JSON decoding.
+	 *
+	 * @return array<string, string> Manifest entries, or an empty array if unavailable/invalid.
+	 */
+	private function get_assets_manifest(): array {
+		static $manifest = null;
+
+		if ( null !== $manifest ) {
+			return $manifest;
+		}
+
+		$manifest      = [];
+		$manifest_path = \get_theme_file_path( '/dist/assets.json' );
+
+		if ( ! file_exists( $manifest_path ) ) {
+			return $manifest;
+		}
+
+		$json   = file_get_contents( $manifest_path ); //phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$assets = json_decode( $json, true );
+
+		if ( ! is_array( $assets ) || JSON_ERROR_NONE !== json_last_error() ) {
+			return $manifest;
+		}
+
+		$manifest = $assets;
+
+		return $manifest;
 	}
 
 	/**

--- a/inc/Services/Editor.php
+++ b/inc/Services/Editor.php
@@ -71,8 +71,15 @@ class Editor implements Service {
 
 	/**
 	 * editor style
+	 *
+	 * Editor styles are only consumed in admin/editor context: skip the
+	 * manifest lookup and filesystem check on front-end requests.
 	 */
 	private function style(): void {
+		if ( ! is_admin() ) {
+			return;
+		}
+
 		$file = $this->assets->get_min_file( 'editor.css' ) ?: 'editor.css';
 
 		/**

--- a/inc/Services/Editor_Patterns.php
+++ b/inc/Services/Editor_Patterns.php
@@ -6,6 +6,12 @@ namespace BEA\Theme\Framework\Services;
 use BEA\Theme\Framework\Service;
 use BEA\Theme\Framework\Service_Container;
 
+/**
+ * Register the theme block pattern categories.
+ *
+ * The patterns themselves (PHP files in `./patterns/`) are automatically
+ * registered by WordPress core since 6.0 (`_register_theme_block_patterns()`).
+ */
 class Editor_Patterns implements Service {
 	/**
 	 * @param Service_Container $container
@@ -25,7 +31,6 @@ class Editor_Patterns implements Service {
 	 */
 	public function boot( Service_Container $container ): void {
 		\add_action( 'init', [ $this, 'register_categories' ], 10 );
-		\add_action( 'init', [ $this, 'register_patterns' ], 11 );
 	}
 
 	/**
@@ -45,177 +50,6 @@ class Editor_Patterns implements Service {
 				continue;
 			}
 			register_block_pattern_category( $name, $properties );
-		}
-	}
-
-	/**
-	 * Register any patterns that the active theme may provide under its
-	 * `./patterns/` directory. Each pattern is defined as a PHP file and defines
-	 * its metadata using plugin-style headers. The minimum required definition is:
-	 *
-	 *     /**
-	 *      * Title: My Pattern
-	 *      * Slug: my-theme/my-pattern
-	 *      *
-	 *
-	 * The output of the PHP source corresponds to the content of the pattern, e.g.:
-	 *
-	 *     <main><p><?php echo "Hello"; ?></p></main>
-	 *
-	 * If applicable, this will collect from both parent and child theme.
-	 *
-	 * Other settable fields include:
-	 *
-	 *   - Description
-	 *   - Viewport Width
-	 *   - Categories       (comma-separated values)
-	 *   - Keywords         (comma-separated values)
-	 *   - Block Types      (comma-separated values)
-	 *   - Inserter         (yes/no)
-	 *
-	 * @since 6.0.0
-	 * @access private
-	 * @internal
-	 * @see https://github.com/WordPress/gutenberg/blob/trunk/lib/compat/wordpress-6.0/block-patterns.php
-	 */
-	public function register_patterns(): void {
-
-		/**
-		 * this function is already present in WordPress 6
-		 */
-		if ( version_compare( get_bloginfo( 'version' ), '6.0', '>=' ) ) {
-			return;
-		}
-
-		$default_headers = [
-			'title'         => 'Title',
-			'slug'          => 'Slug',
-			'description'   => 'Description',
-			'viewportWidth' => 'Viewport Width',
-			'categories'    => 'Categories',
-			'keywords'      => 'Keywords',
-			'blockTypes'    => 'Block Types',
-			'inserter'      => 'Inserter',
-		];
-
-		// Register patterns for the active theme. If the theme is a child theme,
-		// let it override any patterns from the parent theme that shares the same slug.
-		$themes     = [];
-		$stylesheet = get_stylesheet();
-		$template   = get_template();
-		if ( $stylesheet !== $template ) {
-			$themes[] = wp_get_theme( $stylesheet );
-		}
-		$themes[] = wp_get_theme( $template );
-
-		foreach ( $themes as $theme ) {
-			$dirpath = $theme->get_stylesheet_directory() . '/patterns/';
-			if ( ! is_dir( $dirpath ) || ! is_readable( $dirpath ) ) {
-				continue;
-			}
-			$files = glob( $dirpath . '*.php' );
-			if ( is_array( $files ) && count( $files ) > 0 ) {
-				foreach ( $files as $file ) {
-					$pattern_data = get_file_data( $file, $default_headers );
-					if ( empty( $pattern_data['slug'] ) ) {
-						_doing_it_wrong(
-							'_register_theme_block_patterns',
-							sprintf(
-							/* translators: %s: file name. */
-								esc_html__( 'Could not register file "%s" as a block pattern ("Slug" field missing)', 'beapi-frontend-framework' ),
-								esc_html( $file )
-							),
-							'6.0.0'
-						);
-						continue;
-					}
-
-					if ( ! preg_match( '/^[A-z0-9\/_-]+$/', $pattern_data['slug'] ) ) {
-						_doing_it_wrong(
-							'_register_theme_block_patterns',
-							sprintf(
-							/* translators: %1s: file name; %2s: slug value found. */
-								esc_html__( 'Could not register file "%1$s" as a block pattern (invalid slug "%2$s")', 'beapi-frontend-framework' ),
-								esc_html( $file ),
-								esc_html( $pattern_data['slug'] )
-							),
-							'6.0.0'
-						);
-					}
-					if ( \WP_Block_Patterns_Registry::get_instance()->is_registered( $pattern_data['slug'] ) ) {
-						continue;
-					}
-
-					// Title is a required property.
-					if ( ! $pattern_data['title'] ) {
-						_doing_it_wrong(
-							'_register_theme_block_patterns',
-							sprintf(
-							/* translators: %1s: file name; %2s: slug value found. */
-								esc_html__( 'Could not register file "%s" as a block pattern ("Title" field missing)', 'beapi-frontend-framework' ),
-								esc_html( $file )
-							),
-							'6.0.0'
-						);
-						continue;
-					}
-
-					// For properties of type array, parse data as comma-separated.
-					foreach ( [ 'categories', 'keywords', 'blockTypes' ] as $property ) {
-						if ( ! empty( $pattern_data[ $property ] ) ) {
-							$pattern_data[ $property ] = array_filter(
-								preg_split(
-									'/[\s,]+/',
-									(string) $pattern_data[ $property ]
-								)
-							);
-						} else {
-							unset( $pattern_data[ $property ] );
-						}
-					}
-
-					// Parse properties of type int.
-					foreach ( [ 'viewportWidth' ] as $property ) {
-						if ( ! empty( $pattern_data[ $property ] ) ) {
-							$pattern_data[ $property ] = (int) $pattern_data[ $property ];
-						} else {
-							unset( $pattern_data[ $property ] );
-						}
-					}
-
-					// Parse properties of type bool.
-					foreach ( [ 'inserter' ] as $property ) {
-						if ( ! empty( $pattern_data[ $property ] ) ) {
-							$pattern_data[ $property ] = in_array(
-								strtolower( $pattern_data[ $property ] ),
-								[ 'yes', 'true' ],
-								true
-							);
-						} else {
-							unset( $pattern_data[ $property ] );
-						}
-					}
-
-					// Translate the pattern metadata.
-					$text_domain = $theme->get( 'TextDomain' );
-					//phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.NonSingularStringLiteralContext, WordPress.WP.I18n.NonSingularStringLiteralDomain, WordPress.WP.I18n.LowLevelTranslationFunction
-					$pattern_data['title'] = translate_with_gettext_context( $pattern_data['title'], 'Pattern title', $text_domain );
-					if ( ! empty( $pattern_data['description'] ) ) {
-						//phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.NonSingularStringLiteralContext, WordPress.WP.I18n.NonSingularStringLiteralDomain, WordPress.WP.I18n.LowLevelTranslationFunction
-						$pattern_data['description'] = translate_with_gettext_context( $pattern_data['description'], 'Pattern description', $text_domain );
-					}
-
-					// The actual pattern content is the output of the file.
-					ob_start();
-					include $file;
-					$pattern_data['content'] = ob_get_clean();
-					if ( empty( $pattern_data['content'] ) ) {
-						continue;
-					}
-
-					register_block_pattern( $pattern_data['slug'], $pattern_data );
-				}
-			}
 		}
 	}
 }

--- a/style.css
+++ b/style.css
@@ -7,4 +7,5 @@ Author: BeAPI
 Author URI: http://www.beapi.fr
 Text Domain: beapi-frontend-framework
 Requires at least: 6.3
+Requires PHP: 8.3
 */


### PR DESCRIPTION
## Contexte

Revue de performance du framework. Trois hotspots corrigés, aucun changement de comportement attendu.

## Changements

### 1. `Assets::get_min_file()` — memoïsation du manifest `assets.json`
Le fichier `dist/assets.json` était relu et re-décodé (`file_exists` + `file_get_contents` + `json_decode`) **à chaque appel**, et la méthode est appelée plusieurs fois par requête : `register_assets()` (JS), filtre `stylesheet_uri` (déclenché à chaque `get_stylesheet_uri()`), `Editor::style()`, `login_stylesheet_uri()`.

Le manifest décodé est désormais memoïsé en static (`get_assets_manifest()`), sur le même modèle que `get_asset_data()` qui avait déjà son cache.

### 2. `Editor_Patterns` — suppression du backport WP < 6.0
`register_patterns()` (~140 lignes) s'auto-désactivait sur WP ≥ 6.0 mais restait accroché sur `init` à chaque requête. Le core enregistre lui-même les patterns du dossier `./patterns/` depuis la 6.0 (`_register_theme_block_patterns()`), et le thème requiert déjà WP 6.3 (`style.css`). Code supprimé, seul `register_categories()` est conservé.

### 3. `Editor::style()` — garde `is_admin()`
La méthode s'exécutait au boot sur **toutes** les requêtes (front incluse) : lookup manifest + `is_file()`, alors qu'`add_editor_style()` n'est consommé qu'en contexte admin/éditeur.

### 4. Pré-requis PHP/WP déclarés
- `style.css` : ajout de `Requires PHP: 8.3`
- README : nouvelle section **PHP & WordPress** (PHP 8.3+, WP 6.3+)

Versions alignées sur l'existant : `phpcs.xml.dist` (`testVersion 8.3-`), platform composer (`php: 8.3.0`), wp-env (PHP 8.3), `Requires at least: 6.3`.

## Vérifications

- `php -l` OK sur les 3 fichiers modifiés
- phpcs OK (GrumPHP pre-commit au vert)

## Piste non traitée ici (à discuter)

La dépendance jQuery imposée en dur sur le bundle front (`Assets.php` : `array_merge( [ 'jquery' ], … )`) + l'inline script du service `Performance` accroché sur `jquery` garantissent ~30 Ko gzip de JS sur chaque page, même si rien ne l'utilise. C'est le plus gros gain potentiel côté Core Web Vitals, mais c'est un breaking change pour les projets enfants — à traiter dans une PR dédiée si l'équipe valide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance and dead-code removal aligned with existing WP 6.3+ requirements; behavior should be unchanged except dropping unsupported WP <6.0 pattern registration.
> 
> **Overview**
> This PR trims per-request overhead in the theme asset and editor bootstrap paths and documents minimum PHP/WordPress versions.
> 
> **`Assets`** now loads `dist/assets.json` through a private **`get_assets_manifest()`** with a static cache, so repeated **`get_min_file()`** calls (front scripts, **`stylesheet_uri`**, login CSS, editor assets) no longer re-read and decode the manifest on every invocation.
> 
> **`Editor::style()`** returns immediately on non-admin requests so editor CSS manifest and file checks do not run on the front end.
> 
> **`Editor_Patterns`** drops the custom **`register_patterns()`** backport and its **`init`** hook; pattern files under `./patterns/` are left to WordPress core (6.0+), while **`register_categories()`** remains. **`style.css`** adds **`Requires PHP: 8.3`**; the README adds an explicit **PHP 8.3+** and **WordPress 6.3+** requirements section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 486448a2deffd4de83f623e451c6a0a52cc1b82f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->